### PR TITLE
Make methods getContentsFromUrl and generateRandomString static.

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -58,7 +58,7 @@ class Instagram
         return Account::fromAccountPage($userArray);
     }
 
-    private function getContentsFromUrl($parameters)
+    private static function getContentsFromUrl($parameters)
     {
         if (!function_exists('curl_init')) {
             return false;
@@ -79,7 +79,7 @@ class Instagram
         return $output;
     }
 
-    private function generateRandomString($length = 10)
+    private static function generateRandomString($length = 10)
     {
         $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $charactersLength = strlen($characters);


### PR DESCRIPTION
Avoid
```
 [ErrorException]
  Non-static method InstagramScraper\Instagram::generateRandomString() should not be called statically
```
error.

In PHP 5, calling non-static methods statically generates an E_STRICT level warning.
In PHP 7, calling non-static methods statically is deprecated, and will generate an E_DEPRECATED warning. Support for calling non-static methods statically may be removed in the future.