### PR TITLE
String input param support on parseCookies()

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -285,6 +285,10 @@ class Instagram
 
     private static function parseCookies($rawCookies)
     {
+        if(!is_array($rawCookies)){
+            $rawCookies = [$rawCookies];
+        }
+        
         $cookies = [];
         foreach ($rawCookies as $c) {
             $c = explode(';', $c)[0];


### PR DESCRIPTION
Response on the `https://www.instagram.com/accounts/login/ajax/` endpoint request has `Set-Cookie` header with string value (not array), but `Instagram::parseCookies($rawCookie)` method expects only array input parameter.