### PR TITLE
fixes mapping to media videoViews

### DIFF
--- a/src/InstagramScraper/Model/Media.php
+++ b/src/InstagramScraper/Model/Media.php
@@ -99,7 +99,7 @@ class Media
         if ($mediaArray['is_video']) {
             $instance->type = 'video';
             $instance->videoStandardResolutionUrl = $mediaArray['video_url'];
-            $instance->videoViews = $mediaArray['video_views'];
+            $instance->videoViews = $mediaArray['video_view_count'];
         }
         if (isset($mediaArray['caption_is_edited'])) {
             $instance->captionIsEdited = $mediaArray['caption_is_edited'];


### PR DESCRIPTION
This PR fixes the following error:
> ```ErrorException in Media.php line 102: Undefined index: video_views```

The `video_views` index was renamed to `video_view_count`.

