### PR TITLE
Added support for 'carousel' albums

### DIFF
--- a/src/InstagramScraper.php
+++ b/src/InstagramScraper.php
@@ -4,6 +4,7 @@ require_once dirname(__FILE__) . '/InstagramScraper/Instagram.php';
 require_once dirname(__FILE__) . '/InstagramScraper/Endpoints.php';
 require_once dirname(__FILE__) . '/InstagramScraper/InstagramQueryId.php';
 require_once dirname(__FILE__) . '/InstagramScraper/Model/Account.php';
+require_once dirname(__FILE__) . '/InstagramScraper/Model/CarouselMedia.php';
 require_once dirname(__FILE__) . '/InstagramScraper/Model/Comment.php';
 require_once dirname(__FILE__) . '/InstagramScraper/Model/Location.php';
 require_once dirname(__FILE__) . '/InstagramScraper/Model/Media.php';

--- a/src/InstagramScraper/Model/CarouselMedia.php
+++ b/src/InstagramScraper/Model/CarouselMedia.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace InstagramScraper\Model;
+
+use InstagramScraper\Endpoints;
+
+class CarouselMedia
+{
+    const TYPE_IMAGE = 'image';
+    const TYPE_VIDEO = 'video';
+    const TYPE_SIDECAR = 'sidecar';
+
+
+    public $type;
+    public $imageLowResolutionUrl;
+    public $imageThumbnailUrl;
+    public $imageStandardResolutionUrl;
+    public $imageHighResolutionUrl;
+    public $videoLowResolutionUrl;
+    public $videoStandardResolutionUrl;
+    public $videoLowBandwidthUrl;
+    public $videoViews;
+
+    function __construct()
+    {
+    }
+
+}

--- a/src/InstagramScraper/Model/Media.php
+++ b/src/InstagramScraper/Model/Media.php
@@ -9,7 +9,8 @@ class Media
     const TYPE_IMAGE = 'image';
     const TYPE_VIDEO = 'video';
     const TYPE_SIDECAR = 'sidecar';
-
+	const TYPE_CAROUSEL = 'carousel';
+	
 
     public $id;
     public $shortcode;
@@ -21,6 +22,7 @@ class Media
     public $imageThumbnailUrl;
     public $imageStandardResolutionUrl;
     public $imageHighResolutionUrl;
+	public $carouselMedia;
     public $caption;
     public $captionIsEdited;
     public $isAd;
@@ -54,6 +56,34 @@ class Media
         $instance->imageThumbnailUrl = $images['thumbnail'];
         $instance->imageStandardResolutionUrl = $images['standard'];
         $instance->imageHighResolutionUrl = $images['high'];
+		if(isset($mediaArray["carousel_media"])){
+			$instance->carouselMedia = array();
+			foreach($mediaArray["carousel_media"] as $carouselArray){
+				$carouselMedia = new CarouselMedia();
+				$carouselMedia->type = $carouselArray['type'];
+				
+				if (isset($carouselArray['images'])) {
+					$carouselImages = self::getImageUrls($carouselArray['images']['standard_resolution']['url']);
+					$carouselMedia->imageLowResolutionUrl = $carouselImages['low'];
+					$carouselMedia->imageThumbnailUrl = $carouselImages['thumbnail'];
+					$carouselMedia->imageStandardResolutionUrl = $carouselImages['standard'];
+					$carouselMedia->imageHighResolutionUrl = $carouselImages['high'];
+				}
+				
+				if ($carouselMedia->type === 'video') {
+					if (isset($mediaArray['video_views'])) {
+						$carouselMedia->videoViews = $carouselArray['video_views'];
+					}
+					if (isset($carouselArray['videos'])) {
+						$carouselMedia->videoLowResolutionUrl = $carouselArray['videos']['low_resolution']['url'];
+						$carouselMedia->videoStandardResolutionUrl = $carouselArray['videos']['standard_resolution']['url'];
+						$carouselMedia->videoLowBandwidthUrl = $carouselArray['videos']['low_bandwidth']['url'];
+					}
+				}
+				array_push($instance->carouselMedia, $carouselMedia);
+			}
+		}
+		
         if (isset($mediaArray['caption'])) {
             $instance->caption = $mediaArray['caption']['text'];
         }
@@ -147,6 +177,7 @@ class Media
         $instance->imageLowResolutionUrl = $images['low'];
         $instance->imageHighResolutionUrl = $images['high'];
         $instance->imageThumbnailUrl = $images['thumbnail'];
+		$instance->carouselMedia = $mediaArray["carousel_media"];
         $instance->type = 'image';
         if ($mediaArray['is_video']) {
             $instance->type = 'video';

--- a/src/InstagramScraper/Model/Media.php
+++ b/src/InstagramScraper/Model/Media.php
@@ -131,6 +131,34 @@ class Media
             $instance->videoStandardResolutionUrl = $mediaArray['video_url'];
             $instance->videoViews = $mediaArray['video_view_count'];
         }
+		if(isset($mediaArray["carousel_media"])){
+			$instance->type = 'carousel';
+			$instance->carouselMedia = array();
+			foreach($mediaArray["carousel_media"] as $carouselArray){
+				$carouselMedia = new CarouselMedia();
+				$carouselMedia->type = $carouselArray['type'];
+				
+				if (isset($carouselArray['images'])) {
+					$carouselImages = self::getImageUrls($carouselArray['images']['standard_resolution']['url']);
+					$carouselMedia->imageLowResolutionUrl = $carouselImages['low'];
+					$carouselMedia->imageThumbnailUrl = $carouselImages['thumbnail'];
+					$carouselMedia->imageStandardResolutionUrl = $carouselImages['standard'];
+					$carouselMedia->imageHighResolutionUrl = $carouselImages['high'];
+				}
+				
+				if ($carouselMedia->type === 'video') {
+					if (isset($mediaArray['video_views'])) {
+						$carouselMedia->videoViews = $carouselArray['video_views'];
+					}
+					if (isset($carouselArray['videos'])) {
+						$carouselMedia->videoLowResolutionUrl = $carouselArray['videos']['low_resolution']['url'];
+						$carouselMedia->videoStandardResolutionUrl = $carouselArray['videos']['standard_resolution']['url'];
+						$carouselMedia->videoLowBandwidthUrl = $carouselArray['videos']['low_bandwidth']['url'];
+					}
+				}
+				array_push($instance->carouselMedia, $carouselMedia);
+			}
+		}
         if (isset($mediaArray['caption_is_edited'])) {
             $instance->captionIsEdited = $mediaArray['caption_is_edited'];
         }
@@ -177,12 +205,39 @@ class Media
         $instance->imageLowResolutionUrl = $images['low'];
         $instance->imageHighResolutionUrl = $images['high'];
         $instance->imageThumbnailUrl = $images['thumbnail'];
-		$instance->carouselMedia = $mediaArray["carousel_media"];
         $instance->type = 'image';
         if ($mediaArray['is_video']) {
             $instance->type = 'video';
             $instance->videoViews = $mediaArray['video_views'];
         }
+		if(isset($mediaArray["carousel_media"])){
+			$instance->type = 'carousel';
+			$instance->carouselMedia = array();
+			foreach($mediaArray["carousel_media"] as $carouselArray){
+				$carouselMedia = new CarouselMedia();
+				$carouselMedia->type = $carouselArray['type'];
+				
+				if (isset($carouselArray['images'])) {
+					$carouselImages = self::getImageUrls($carouselArray['images']['standard_resolution']['url']);
+					$carouselMedia->imageLowResolutionUrl = $carouselImages['low'];
+					$carouselMedia->imageThumbnailUrl = $carouselImages['thumbnail'];
+					$carouselMedia->imageStandardResolutionUrl = $carouselImages['standard'];
+					$carouselMedia->imageHighResolutionUrl = $carouselImages['high'];
+				}
+				
+				if ($carouselMedia->type === 'video') {
+					if (isset($mediaArray['video_views'])) {
+						$carouselMedia->videoViews = $carouselArray['video_views'];
+					}
+					if (isset($carouselArray['videos'])) {
+						$carouselMedia->videoLowResolutionUrl = $carouselArray['videos']['low_resolution']['url'];
+						$carouselMedia->videoStandardResolutionUrl = $carouselArray['videos']['standard_resolution']['url'];
+						$carouselMedia->videoLowBandwidthUrl = $carouselArray['videos']['low_bandwidth']['url'];
+					}
+				}
+				array_push($instance->carouselMedia, $carouselMedia);
+			}
+		}
         $instance->id = $mediaArray['id'];
         return $instance;
     }


### PR DESCRIPTION
Added support for the 'carousel' media types, also known as "Instagram Albums". The video's and images are stored in an array in the "carouselMedia" variable. As requested in issue #64 