### PR TITLE
Fix getAccountById failure using follow url.

### DIFF
--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -103,4 +103,9 @@ class Endpoints
         }
         return $url;
     }
+
+    public static function getFollowUrl($accountId){
+        $url = str_replace('{{accountId}}', urlencode($accountId), Endpoints::FOLLOW_URL);
+        return $url;
+    }
 }


### PR DESCRIPTION
Fixes #132.

It turns out the a get request to `EndPoints::FOLLOW_URL`  will load that user's home page, thus netting us their account. This should solve many issues that have been arising with getAccountById.