### PR TITLE
Hotfix bad string coercion. Fixes #139.

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -309,7 +309,7 @@ class Instagram
         $response = Request::get($url, $this->generateHeaders($this->userSession));
 
         if ($response->code !== 200) {
-            throw new InstagramException('Response code is ' . $response->code . '. Body: ' . $response->body . ' Something went wrong. Please report issue.');
+            throw new InstagramException('Response code is ' . $response->code . '. Body: ' . $response->raw_body . ' Something went wrong. Please report issue.');
         }
 
         $cookies = self::parseCookies($response->headers['Set-Cookie']);


### PR DESCRIPTION
More error handling is needed, but this should be put in right away to fix the problem.
Alternatively, we could rollback my previous PR, but as the function was broken anyway, it seems unnecessary.