### PR TITLE
Fix PHP Notice on ArrayLikeTrait

### DIFF
--- a/src/InstagramScraper/Traits/ArrayLikeTrait.php
+++ b/src/InstagramScraper/Traits/ArrayLikeTrait.php
@@ -36,10 +36,14 @@ trait ArrayLikeTrait
         if ($run = $this->isMethod($offset, 'get')) {
             return $this->run($run);
         } elseif (\property_exists($this, $offset)) {
-            return $this->{$offset};
-        } else {
-            return null;
+            if (isset($this->{$offset})) {
+                return $this->{$offset};
+            } elseif (isset($this::$offset)) {
+                return $this::$offset;
+            }
         }
+        
+        return null;
     }
 
     /**


### PR DESCRIPTION
`PHP Notice:  Accessing static property InstagramScraper\Model\Media::$initPropertiesMap as non static in /vendor/raiym/instagram-php-scraper/src/InstagramScraper/Traits/ArrayLikeTrait.php on line 39
`

ArrayLikeTrait were giving above error since class properties has been changed to static. So this update removes this error log. 