### PR TITLE
Hotfix for Instagram changes

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -234,7 +234,7 @@ class Instagram
             if (!is_array($arr)) {
                 throw new InstagramException('Response code is ' . $response->code . '. Body: ' . static::getErrorBody($response->body) . ' Something went wrong. Please report issue.');
             }
-            $nodes = $arr['user']['media']['nodes'];
+            $nodes = $arr['graphql']['user']['edge_owner_to_timeline_media']['edges'];
             // fix - count takes longer/has more overhead
             if (!isset($nodes) || empty($nodes)) {
                 return [];
@@ -243,14 +243,14 @@ class Instagram
                 if ($index === $count) {
                     return $medias;
                 }
-                $medias[] = Media::create($mediaArray);
+                $medias[] = Media::create($mediaArray['node']);
                 $index++;
             }
             if (empty($nodes) || !isset($nodes)) {
                 return $medias;
             }
-            $maxId = $nodes[count($nodes) - 1]['id'];
-            $isMoreAvailable = $arr['user']['media']['page_info']['has_next_page'];
+            $maxId = $nodes[count($nodes) - 1]['node']['id'];
+            $isMoreAvailable = $arr['graphql']['user']['edge_owner_to_timeline_media']['page_info']['has_next_page'];
         }
         return $medias;
     }
@@ -589,10 +589,10 @@ class Instagram
         }
 
         $userArray = json_decode($response->raw_body, true, 512, JSON_BIGINT_AS_STRING);
-        if (!isset($userArray['user'])) {
+        if (!isset($userArray['graphql']['user'])) {
             throw new InstagramException('Account with this username does not exist');
         }
-        return Account::create($userArray['user']);
+        return Account::create($userArray['graphql']['user']);
     }
 
     /**

--- a/src/InstagramScraper/Model/Account.php
+++ b/src/InstagramScraper/Model/Account.php
@@ -228,13 +228,13 @@ class Account extends AbstractModel
             case 'external_url':
                 $this->externalUrl = $value;
                 break;
-            case 'follows':
+            case 'edge_follow':
                 $this->followsCount = !empty($array[$prop]['count']) ? (int)$array[$prop]['count'] : 0;
                 break;
-            case 'followed_by':
+            case 'edge_followed_by':
                 $this->followedByCount = !empty($array[$prop]['count']) ? (int)$array[$prop]['count'] : 0;
                 break;
-            case 'media':
+            case 'edge_owner_to_timeline_media':
                 $this->mediaCount = !empty($array[$prop]['count']) ? $array[$prop]['count'] : 0;
                 break;
             case 'is_private':


### PR DESCRIPTION
Fixed error "Account with this username does not exist"

Known problem with this pull request (https://github.com/postaddictme/instagram-php-scraper/issues/288):

"max_id" doesn't work anymore for this endpoint :
`https://www.instagram.com/{username}/?__a=1&max_id={max_id}`
So paginated requests return same content.

