### PR TITLE
 Allow configuring how many media objects are retrieved in a single request for ACCOUNT_MEDIAS

### DIFF
--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -8,7 +8,7 @@ class Endpoints
     const LOGIN_URL = 'https://www.instagram.com/accounts/login/ajax/';
     const ACCOUNT_PAGE = 'https://www.instagram.com/{username}';
     const MEDIA_LINK = 'https://www.instagram.com/p/{code}';
-    const ACCOUNT_MEDIAS = 'https://instagram.com/graphql/query/?query_id=17888483320059182&id={user_id}&first=30&after={max_id}';
+    const ACCOUNT_MEDIAS = 'https://instagram.com/graphql/query/?query_id=17888483320059182&id={user_id}&first={count}&after={max_id}';
     const ACCOUNT_JSON_INFO = 'https://www.instagram.com/{username}/?__a=1';
     const MEDIA_JSON_INFO = 'https://www.instagram.com/p/{code}/?__a=1';
     const MEDIA_JSON_BY_LOCATION_ID = 'https://www.instagram.com/explore/locations/{{facebookLocationId}}/?__a=1&max_id={{maxId}}';
@@ -34,6 +34,16 @@ class Endpoints
 
     const GRAPH_QL_QUERY_URL = 'https://www.instagram.com/graphql/query/?query_id={{queryId}}';
 
+    private static $requestMediaCount = 30;
+
+    /**
+     * @param int $count
+     */
+    public static function setAccountMediasRequestCount($count)
+    {
+        static::$requestMediaCount = $count;
+    }
+
     public static function getAccountPageLink($username)
     {
         return str_replace('{username}', urlencode($username), static::ACCOUNT_PAGE);
@@ -52,6 +62,7 @@ class Endpoints
     public static function getAccountMediasJsonLink($userId, $maxId = '')
     {
     	$url = str_replace('{user_id}', urlencode($userId), static::ACCOUNT_MEDIAS);
+        $url = str_replace('{count}', static::$requestMediaCount, $url);
     	return str_replace('{max_id}', urlencode($maxId), $url);
     }
 

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -101,6 +101,15 @@ class Instagram
     }
 
     /**
+     * Set how many media objects should be retrieved in a single request
+     * @param int $count
+     */
+    public static function setAccountMediasRequestCount($count)
+    {
+        Endpoints::setAccountMediasRequestCount($count);
+    }
+
+    /**
      * @param \stdClass|string $rawError
      *
      * @return string

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -358,7 +358,7 @@ class Instagram
     	}
     	
     	$maxId = $arr['data']['user']['edge_owner_to_timeline_media']['page_info']['end_cursor'];
-    	$isMoreAvailable = $arr['data']['user']['edge_owner_to_timeline_media']['page_info']['has_next_page'];
+        $hasNextPage = $arr['data']['user']['edge_owner_to_timeline_media']['page_info']['has_next_page'];
     	
     	$toReturn = [
     		'medias' => $medias,


### PR DESCRIPTION
When retrieving a lot of media objects it may be useful to be able to configure how many objects you want to receive via a single request. I.e. if you're fetching 500 objects, it's better to have fewer requests, to make it quicker and try to avoid the rate limits.

I left the default as `30` as before. Changing the limit is simply one static call:
```
Instagram::setAccountMediasRequestCount(150);
```