### PR TITLE
Moved to psr-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,13 @@
     "phpunit/phpunit": "5.5.*"
   },
   "autoload": {
-    "psr-0": {
-      "InstagramScraper": "src"
+    "psr-4": {
+      "InstagramScraper\\": "src/InstagramScraper/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "InstagramScraper\\Tests\\": "tests/"
     }
   },
   "support": {

--- a/tests/InstagramTest.php
+++ b/tests/InstagramTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace InstagramScraper\Tests;
+
 use InstagramScraper\Instagram;
 use InstagramScraper\Model\Media;
 use phpFastCache\CacheManager;


### PR DESCRIPTION
- PSR-0 has been marked as deprecated. PSR-4 is now recommended as an alternative. https://www.php-fig.org/psr/psr-0/
- Added autoload-dev to define autoload rules for development purposes. see https://getcomposer.org/doc/04-schema.md#autoload-dev