### PR TITLE
fix login - add cookie banner cookie

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1277,7 +1277,7 @@ class Instagram
 			endif;
             $mid = $cookies['mid'];
             $headers = [
-                'cookie' => "csrftoken=$csrfToken; mid=$mid;",
+                'cookie' => "ig_cb=1; csrftoken=$csrfToken; mid=$mid;",
                 'referer' => Endpoints::BASE_URL . '/',
                 'x-csrftoken' => $csrfToken,
                 'X-CSRFToken' => $csrfToken,
@@ -1331,7 +1331,7 @@ class Instagram
         $sessionId = $session['sessionid'];
         $csrfToken = $session['csrftoken'];
         $headers = [
-            'cookie' => "csrftoken=$csrfToken; sessionid=$sessionId;",
+            'cookie' => "ig_cb=1; csrftoken=$csrfToken; sessionid=$sessionId;",
             'referer' => Endpoints::BASE_URL . '/',
             'x-csrftoken' => $csrfToken,
             'X-CSRFToken' => $csrfToken,


### PR DESCRIPTION
The login is not workling because of the mission ig_cb (instagram cookie banner) cookie.
Fixed it, please release a new version as soon as possible