### PR TITLE
Handle new fields of Account and Media

### DIFF
--- a/src/InstagramScraper/Model/Account.php
+++ b/src/InstagramScraper/Model/Account.php
@@ -86,6 +86,91 @@ class Account extends AbstractModel
     protected $isLoaded = false;
 
     /**
+     * @var Media[]
+     */
+    protected $medias = [];
+
+    /**
+     * @var bool
+     */
+    protected $blockedByViewer = false;
+
+    /**
+     * @var bool
+     */
+    protected $countryBlock = false;
+
+    /**
+     * @var bool
+     */
+    protected $followedByViewer = false;
+
+    /**
+     * @var bool
+     */
+    protected $followsViewer = false;
+
+    /**
+     * @var bool
+     */
+    protected $hasChannel = false;
+
+    /**
+     * @var bool
+     */
+    protected $hasBlockedViewer = false;
+
+    /**
+     * @var int
+     */
+    protected $highlightReelCount = 0;
+
+    /**
+     * @var bool
+     */
+    protected $hasRequestedViewer = false;
+
+    /**
+     * @var bool
+     */
+    protected $isBusinessAccount = false;
+
+    /**
+     * @var bool
+     */
+    protected $isJoinedRecently = false;
+
+    /**
+     * @var string
+     */
+    protected $businessCategoryName = '';
+
+    /**
+     * @var string
+     */
+    protected $businessEmail = '';
+
+    /**
+     * @var string
+     */
+    protected $businessPhoneNumber = '';
+
+    /**
+     * @var string
+     */
+    protected $businessAddressJson = '{}';
+
+    /**
+     * @var bool
+     */
+    protected $requestedByViewer = false;
+
+    /**
+     * @var string
+     */
+    protected $connectedFbPage = '';
+
+    /**
      * @return bool
      */
     public function isLoaded()
@@ -200,6 +285,153 @@ class Account extends AbstractModel
     }
 
     /**
+     * @return Media[]
+     */
+    public function getMedias()
+    {
+        return $this->medias;
+    }
+
+    /**
+     * @param Media $media
+     * @return Account
+     */
+    public function addMedia(Media $media)
+    {
+        $this->medias[] = $media;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isBlockedByViewer()
+    {
+        return $this->blockedByViewer;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCountryBlock()
+    {
+        return $this->countryBlock;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFollowedByViewer()
+    {
+        return $this->followedByViewer;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFollowsViewer()
+    {
+        return $this->followsViewer;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHasChannel()
+    {
+        return $this->hasChannel;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHasBlockedViewer()
+    {
+        return $this->hasBlockedViewer;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHighlightReelCount()
+    {
+        return $this->highlightReelCount;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHasRequestedViewer()
+    {
+        return $this->hasRequestedViewer;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isBusinessAccount()
+    {
+        return $this->isBusinessAccount;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isJoinedRecently()
+    {
+        return $this->isJoinedRecently;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBusinessCategoryName()
+    {
+        return $this->businessCategoryName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBusinessEmail()
+    {
+        return $this->businessEmail;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBusinessPhoneNumber()
+    {
+        return $this->businessPhoneNumber;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBusinessAddressJson()
+    {
+        return $this->businessAddressJson;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRequestedByViewer()
+    {
+        return $this->requestedByViewer;
+    }
+
+    /**
+     * @return string
+     */
+    public function getConnectedFbPage()
+    {
+        return $this->connectedFbPage;
+    }
+
+    /**
      * @param $value
      * @param $prop
      * @param $array
@@ -236,7 +468,7 @@ class Account extends AbstractModel
                 $this->followedByCount = !empty($array[$prop]['count']) ? (int)$array[$prop]['count'] : 0;
                 break;
             case 'edge_owner_to_timeline_media':
-                $this->mediaCount = !empty($array[$prop]['count']) ? $array[$prop]['count'] : 0;
+                $this->initMedia($array[$prop]);
                 break;
             case 'is_private':
                 $this->isPrivate = (bool)$value;
@@ -244,6 +476,73 @@ class Account extends AbstractModel
             case 'is_verified':
                 $this->isVerified = (bool)$value;
                 break;
+            case 'blocked_by_viewer':
+                $this->blockedByViewer = (bool)$value;
+                break;
+            case 'country_block':
+                $this->countryBlock = (bool)$value;
+                break;
+            case 'followed_by_viewer':
+                $this->followedByViewer = $value;
+                break;
+            case 'follows_viewer':
+                $this->followsViewer = $value;
+                break;
+            case 'has_channel':
+                $this->hasChannel = (bool)$value;
+                break;
+            case 'has_blocked_viewer':
+                $this->hasBlockedViewer = (bool)$value;
+                break;
+            case 'highlight_reel_count':
+                $this->highlightReelCount = (int)$value;
+                break;
+            case 'has_requested_viewer':
+                $this->hasRequestedViewer = (bool)$value;
+                break;
+            case 'is_business_account':
+                $this->isBusinessAccount = (bool)$value;
+                break;
+            case 'is_joined_recently':
+                $this->isJoinedRecently = (bool)$value;
+                break;
+            case 'business_category_name':
+                $this->businessCategoryName = $value;
+                break;
+            case 'business_email':
+                $this->businessEmail = $value;
+                break;
+            case 'business_phone_number':
+                $this->businessPhoneNumber = $value;
+                break;
+            case 'business_address_json':
+                $this->businessAddressJson = $value;
+                break;
+            case 'requested_by_viewer':
+                $this->requestedByViewer = (bool)$value;
+                break;
+            case 'connected_fb_page':
+                $this->connectedFbPage = $value;
+                break;
+        }
+    }
+
+    /**
+     * @param array $array
+     */
+    protected function initMedia($array)
+    {
+        $this->mediaCount = !empty($array['count']) ? $array['count'] : 0;
+        if (!$this->mediaCount || !isset($array['edges']) || !is_array($array['edges'])) {
+            return;
+        }
+
+        $nodes = $array['edges'];
+        foreach ($nodes as $mediaArray) {
+            $media = Media::create($mediaArray['node']);
+            if ($media instanceof Media) {
+                $this->addMedia($media);
+            }
         }
     }
 }

--- a/src/InstagramScraper/Model/Media.php
+++ b/src/InstagramScraper/Model/Media.php
@@ -156,6 +156,11 @@ class Media extends AbstractModel
     protected $sidecarMedias = [];
 
     /**
+     * @var string
+     */
+    protected $locationSlug;
+
+    /**
      * @param string $code
      *
      * @return int
@@ -420,6 +425,14 @@ class Media extends AbstractModel
     }
 
     /**
+     * @return string
+     */
+    public function getLocationSlug()
+    {
+        return $this->locationSlug;
+    }
+
+    /**
      * @param $value
      * @param $prop
      */
@@ -515,6 +528,7 @@ class Media extends AbstractModel
             case 'location':
                 $this->locationId = $arr[$prop]['id'];
                 $this->locationName = $arr[$prop]['name'];
+                $this->locationSlug = $arr[$prop]['slug'];
                 break;
             case 'user':
                 $this->owner = Account::create($arr[$prop]);


### PR DESCRIPTION
It is necessary to get information about account and few last medias in one request. Added new fields.

Account:
```
medias
blocked_by_viewer
country_block
external_url
external_url_linkshimmed
followed_by_viewer
follows_viewer
has_channel
has_blocked_viewer
highlight_reel_count
has_requested_viewer
is_business_account
is_joined_recently
business_category_name
business_email
business_phone_number
business_address_json
requested_by_viewer
connected_fb_page
```
Media:
```
location slug
```

