### PR TITLE
Add getPaginateMediasByUserId method with $count parameter

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -552,6 +552,24 @@ class Instagram
     public function getPaginateMedias($username, $maxId = '')
     {
         $account = $this->getAccount($username);
+
+        return $this->getPaginateMediasByUserId(
+            $account->getId(),
+            Endpoints::getAccountMediasRequestCount(),
+            $maxId
+        );
+    }
+
+    /**
+     * @param int $id
+     * @param int $count
+     * @param string $maxId
+     *
+     * @return array
+     * @throws InstagramException
+     */
+    public function getPaginateMediasByUserId($id, $count = 12, $maxId = '')
+    {
         $hasNextPage = false;
         $medias = [];
 
@@ -562,8 +580,8 @@ class Instagram
         ];
 
         $variables = json_encode([
-            'id' => (string)$account->getId(),
-            'first' => (string)Endpoints::getAccountMediasRequestCount(),
+            'id' => (string)$id,
+            'first' => (string)$count,
             'after' => (string)$maxId
         ]);
 


### PR DESCRIPTION
I created this method from `getPaginateMedias` and added `$count` parameter to it.
I didn't add `$count` parameter to `getPaginateMedias` method for a backward compatibility.