### PR TITLE
remove unnecessary code in getMediasByUserId()

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -386,9 +386,6 @@ class Instagram
                 $medias[] = Media::create($mediaArray['node']);
                 $index++;
             }
-            if (empty($nodes) || !isset($nodes)) {
-                return $medias;
-            }
             $maxId = $arr['data']['user']['edge_owner_to_timeline_media']['page_info']['end_cursor'];
             $isMoreAvailable = $arr['data']['user']['edge_owner_to_timeline_media']['page_info']['has_next_page'];
         }


### PR DESCRIPTION
 in method getMediasByUserId():
```
           // fix - count takes longer/has more overhead    (if the "if" statement run first)
            if (!isset($nodes) || empty($nodes)) {
                return [];
            }
           foreach($nodes as $mediaArray){}

           // (then this code below is unnecessary, should be removed and not to cause confusion)
           if (empty($nodes) || !isset($nodes)) {
                return $medias;
            }
```

and I advise using 'yield' to extend methods like getMediasByUserId() which contain a loop and need to request a url within the loop to collect the whole result. Can simply add a method called 
generateMediasByUserId() and use the 'yield' key word to output the result from one single request.That may avoid waiting long to handle the result if one wants to get 2000 medias from an ig account.In the case, get one response, handle one response, quicken the process~
ps: not good at english, hope it can make sense to you. 