### PR TITLE
 Replace Unirest by Guzzle + Add auto retry for failed requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Instagram::disableProxy();
 $account = $instagram->getAccount('kevin');
 ```
 
-Using a list of failbacks proxies for requests : 
+Using a list of fallbacks proxies for requests :
 
 ```php
 Instagram::setProxies([

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ Instagram::disableProxy();
 $account = $instagram->getAccount('kevin');
 ```
 
+Using a list of failbacks proxies for requests : 
+
+```php
+Instagram::setProxies([
+    '', // Empty or null can be set : no proxy will be used when selected
+    'tcp://127.0.0.1:123',
+    'http://foo:bar@127.0.0.1:456',
+]);
+```
+
+
+Auto Retry Failed Requests (for connections errors, 4xx and 5xx) : 
+
+```php
+Instagram::setAutoRetry(true); // default: false
+Instagram::setMaxNbRetries(3); // default: 3
+```
+
 ## Installation
 
 ### Using composer

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,9 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
-    "mashape/unirest-php": "3.0.*",
-    "phpFastCache/phpFastCache": "5.0.*",
-    "ext-curl": "*",
+    "php": ">=5.5",
+    "guzzlehttp/guzzle": "^6.2",
+    "phpfastcache/phpfastcache": "5.0.*",
     "ext-json": "*"
   },
   "require-dev": {

--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -5,8 +5,9 @@ namespace InstagramScraper;
 class Endpoints
 {
     const BASE_URL = 'https://www.instagram.com';
+    const BASE_LOGIN_URL = 'https://www.instagram.com/accounts/login/';
     const LOGIN_URL = 'https://www.instagram.com/accounts/login/ajax/';
-    const ACCOUNT_PAGE = 'https://www.instagram.com/{username}';
+    const ACCOUNT_PAGE = 'https://www.instagram.com/{username}/';
     const MEDIA_LINK = 'https://www.instagram.com/p/{code}';
     const ACCOUNT_MEDIAS = 'https://www.instagram.com/graphql/query/?query_hash=42323d64886122307be10013ad2dcc44&variables={variables}';
     const ACCOUNT_JSON_INFO = 'https://www.instagram.com/{username}/?__a=1';

--- a/src/InstagramScraper/Exception/Instagram2FactorException.php
+++ b/src/InstagramScraper/Exception/Instagram2FactorException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace InstagramScraper\Exception;
+
+class Instagram2FactorException extends \Exception
+{
+    public function __construct($message = "", $code = 401, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -180,13 +180,12 @@ class Instagram
                     throw new Instagram2FactorException('2 Factor Authentication required', $e->getResponse()->getStatusCode(), $e);
                 }
             }
-            if (static::HTTP_OK !== $e->getResponse()->getStatusCode()) {
-                $this->markFailRequest();
-                if ($this->canRetry()) {
-                    return $this->makeRequest($method, $url, $options, $notFoundMessage, $accessDeniedMessage);
-                }
-                throw new InstagramException('Response code is ' . $e->getResponse()->getStatusCode() . '. Something went wrong. Please report issue.', $e->getResponse()->getStatusCode(), $e);
+
+            $this->markFailRequest();
+            if ($this->canRetry()) {
+                return $this->makeRequest($method, $url, $options, $notFoundMessage, $accessDeniedMessage);
             }
+            throw new InstagramException('Response code is ' . $e->getResponse()->getStatusCode() . '. Something went wrong. Please report issue.', $e->getResponse()->getStatusCode(), $e);
         }
 
         $this->cleanFailedRequest();
@@ -419,7 +418,7 @@ class Instagram
      * @param  array|string $proxy
      * @return string
      */
-    private function getProxyUri($proxy)
+    private static function getProxyUri($proxy)
     {
         if (is_array($proxy)) {
             return self::buildProxyURI($proxy);

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -73,7 +73,7 @@ class Instagram
      *
      * @var integer
      */
-    private static $maxNbRetries = false;
+    private static $maxNbRetries = 3;
 
     /**
      * @var \GuzzleHttp\Client

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -78,6 +78,13 @@ class Instagram
     private static $maxNbRetries = 3;
 
     /**
+     * Number of seconds for maximum timeout before throwing exception.
+     *
+     * @var integer
+     */
+    private static $maxTimeout = self::NETWORK_TIMEOUT;
+
+    /**
      * @var \GuzzleHttp\Client
      */
     private $client;
@@ -112,7 +119,7 @@ class Instagram
 
         $this->client = new Client([
             'cookies' => $cookies,
-            'timeout' => self::NETWORK_TIMEOUT,
+            'timeout' => self::$maxTimeout,
             'allow_redirects' => false,
             'headers' => [
                 'User-Agent' => $this->getUserAgent(),
@@ -408,6 +415,14 @@ class Instagram
     public static function setMaxNbRetries($maxNbRetries)
     {
         static::$maxNbRetries = $maxNbRetries;
+    }
+
+    /**
+     * @param integer $maxTimeout
+     */
+    public static function setMaxTimeout($maxTimeout)
+    {
+        static::$maxTimeout = $maxTimeout;
     }
 
     /**

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -603,7 +603,7 @@ class Instagram
             $arr = $this->decodeRawBodyToJson($response);
 
             if (!is_array($arr)) {
-                throw new InstagramException('Something went wrong. Please report issue. Unable to decode response.', $response);
+                throw new InstagramException('Something went wrong. Please report issue. Unable to decode response.');
             }
 
             $nodes = $arr['data']['user']['edge_owner_to_timeline_media']['edges'];
@@ -789,7 +789,7 @@ class Instagram
         $arr = $this->decodeRawBodyToJson($response);
 
         if (!is_array($arr)) {
-            throw new InstagramException('Something went wrong. Please report issue. Unable to decode response.', $response);
+            throw new InstagramException('Something went wrong. Please report issue. Unable to decode response.');
         }
 
         $nodes = $arr['data']['user']['edge_owner_to_timeline_media']['edges'];

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -152,6 +152,13 @@ class Instagram
             throw $e;
         }
         catch (ClientException|RequestException $e) {
+            if (null === $e->getResponse()) {
+                $this->markFailRequest();
+                if ($this->canRetry()) {
+                    return $this->makeRequest($method, $url, $options, $notFoundMessage, $accessDeniedMessage);
+                }
+                throw new InstagramException('No Response fetched. Something went wrong. Please report issue.', $e->getCode(), $e);
+            }
             if (static::HTTP_NOT_FOUND === $e->getResponse()->getStatusCode()) {
                 throw new InstagramNotFoundException($notFoundMessage, $e->getResponse()->getStatusCode(), $e);
             }

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -43,7 +43,7 @@ class Instagram
 
     const NETWORK_TIMEOUT = 10; // 10 seconds default timeout
 
-    const DEFAULT_USERAGENT = 'Mozilla/5.0 (Linux; Android 8.1.0; motorola one Build/OPKS28.63-18-3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 Instagram 72.0.0.21.98 Android (27/8.1.0; 320dpi; 720x1362; motorola; motorola one; deen_sprout; qcom; pt_BR; 132081645)';
+    const DEFAULT_USERAGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36';
 
     /** @var CacheInterface $instanceCache */
     private static $instanceCache = null;

--- a/tests/InstagramTest.php
+++ b/tests/InstagramTest.php
@@ -2,6 +2,7 @@
 
 namespace InstagramScraper\Tests;
 
+use InstagramScraper\Exception\InstagramNotFoundException;
 use InstagramScraper\Instagram;
 use InstagramScraper\Model\Media;
 use phpFastCache\CacheManager;
@@ -51,7 +52,7 @@ class InstagramTest extends TestCase
     public function testGetAccountByIdWithInvalidNumericId()
     {
         // PHP_INT_MAX is far larger than the greatest id so far and thus does not represent a valid account.
-        $this->expectExceptionMessage('Failed to fetch account with given id');
+        $this->expectException(InstagramNotFoundException::class);
         self::$instagram->getAccountById(PHP_INT_MAX);
     }
 


### PR DESCRIPTION
Hi,

Since I had some unattended errors with Unirest (SSL errors, XXX remaining bytes to read...) during long crawls and that this project seems abandoned, I've replaced the HTTP requests with Guzzle.

One of the advantages of Guzzle is that it can keep the cookies between requests and that they are automatically stored, so the methods `parseCookies` and `generateHeaders` are now useless.

I have also added a retry mechanism when the requests fail, plus the possibility to have multiple proxies that can be switched in order to avoid rate limitations (#330, #494 ...).

The only downside is the 2 factor authorization : according to my tests, the current implementation do not work as there is no more a `$response->body->checkpoint_url` that can be used to submit a code.