### PR TITLE
Throw InstagramException if there is LoginAndSignupPage

### DIFF
--- a/src/InstagramScraper/Exception/InstagramTooManyRequestsException.php
+++ b/src/InstagramScraper/Exception/InstagramTooManyRequestsException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace InstagramScraper\Exception;
+
+class InstagramTooManyRequestsException extends \Exception
+{
+    public function __construct($message = "", $code = 429, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -26,6 +26,7 @@ class Instagram
     const HTTP_OK = 200;
     const HTTP_FORBIDDEN = 403;
     const HTTP_BAD_REQUEST = 400;
+    const HTTP_TOO_MANY_REQUESTS = 429;
 
     const MAX_COMMENTS_PER_REQUEST = 300;
     const MAX_LIKES_PER_REQUEST = 300;
@@ -361,6 +362,13 @@ class Instagram
         }
 
         $userArray = self::extractSharedDataFromBody($response->raw_body);
+
+        if (isset($userArray['entry_data']['LoginAndSignupPage'])) {
+           throw new InstagramException(
+               'Instagram redirected to login and signup page. Rate limiting occured. Try to use other ip or try crawling with authentication.',
+               self::HTTP_TOO_MANY_REQUESTS
+           ) ;
+        }
 
         if (!isset($userArray['entry_data']['ProfilePage'][0]['graphql']['user'])) {
             throw new InstagramNotFoundException('Account with this username does not exist');

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1592,6 +1592,7 @@ class Instagram
      * @param string $notFoundMessage
      * @throws InstagramException
      * @throws InstagramTooManyRequestsException
+     * @throws InstagramNotFoundException
      */
     protected function checkResponseCode(Response $response, $notFoundMessage = 'Instagram returned 404')
     {
@@ -1600,7 +1601,7 @@ class Instagram
         }
 
         if (static::HTTP_NOT_FOUND === $response->code) {
-            throw new InstagramTooManyRequestsException($notFoundMessage);
+            throw new InstagramNotFoundException($notFoundMessage);
         }
 
         if ($response->code !== static::HTTP_OK) {


### PR DESCRIPTION
Lately instagram introduced some sophisticated rate limiting which redirects to login and signup page when fetching user page, now in this case InstagramNotFoundException is thrown but it's not true. This PR solves this at least in code that we can catch correct exception and switch to other proxy.