### PR TITLE
Check if instance of cache is set

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -34,7 +34,7 @@ class Instagram
     const PAGING_DELAY_MAXIMUM_MICROSEC = 3000000; // 3 sec max delay to simulate browser
 
     /** @var ExtendedCacheItemPoolInterface $instanceCache */
-    private static $instanceCache;
+    private static $instanceCache = null;
 
     public $pagingTimeLimitSec = self::PAGING_TIME_LIMIT_SEC;
     public $pagingDelayMinimumMicrosec = self::PAGING_DELAY_MINIMUM_MICROSEC;
@@ -63,7 +63,9 @@ class Instagram
                 'path' => $sessionFolder,
                 'ignoreSymfonyNotice' => true,
             ]);
-            static::$instanceCache = CacheManager::getInstance('files');
+            if (static::$instanceCache === null) {
+                static::$instanceCache = CacheManager::getInstance('files');
+            }
         } else {
             static::$instanceCache = $sessionFolder;
         }


### PR DESCRIPTION
Each time withCredentials is used it's calling getInstance which is not needed. This PR adds a check for it.