### PR TITLE
Avoid the `Invalid argument supplied for foreach()` error in case the post has no comments/likes

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -723,6 +723,10 @@ class Instagram
             $this->parseCookies($response->headers);
             $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
             $nodes = $jsonResponse['data']['shortcode_media']['edge_media_to_comment']['edges'];
+            if (empty($nodes)) {
+                return [];
+            }
+
             foreach ($nodes as $commentArray) {
                 $comments[] = Comment::create($commentArray['node']);
                 $index++;
@@ -822,6 +826,9 @@ class Instagram
             $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
 
             $nodes = $jsonResponse['data']['shortcode_media']['edge_liked_by']['edges'];
+            if (empty($nodes)) {
+                return [];
+            }
 
             foreach ($nodes as $likesArray) {
                 $likes[] = Like::create($likesArray['node']);


### PR DESCRIPTION
Avoid the `Invalid argument supplied for foreach()` error in case the post has no comments/likes
@raiym 