### PR TITLE
Accounts objects, getFollowedBy returns always zero when using searchAccountsByUsername

### DIFF
--- a/src/InstagramScraper/Model/Account.php
+++ b/src/InstagramScraper/Model/Account.php
@@ -468,7 +468,7 @@ class Account extends AbstractModel
                 $this->followedByCount = !empty($array[$prop]['count']) ? (int)$array[$prop]['count'] : 0;
                 break;
             case 'follower_count':
-                $this->followedByCount = empty($array[$prop]['count']) ? $value : 0;
+                $this->followedByCount = empty($array['edge_followed_by']['count']) ? $value : 0;
                 break;
             case 'edge_owner_to_timeline_media':
                 $this->initMedia($array[$prop]);

--- a/src/InstagramScraper/Model/Account.php
+++ b/src/InstagramScraper/Model/Account.php
@@ -468,7 +468,7 @@ class Account extends AbstractModel
                 $this->followedByCount = !empty($array[$prop]['count']) ? (int)$array[$prop]['count'] : 0;
                 break;
             case 'follower_count':
-                $this->followedByCount = $value;
+                $this->followedByCount = empty($array[$prop]['count']) ? $value : 0;
                 break;
             case 'edge_owner_to_timeline_media':
                 $this->initMedia($array[$prop]);

--- a/src/InstagramScraper/Model/Account.php
+++ b/src/InstagramScraper/Model/Account.php
@@ -467,6 +467,9 @@ class Account extends AbstractModel
             case 'edge_followed_by':
                 $this->followedByCount = !empty($array[$prop]['count']) ? (int)$array[$prop]['count'] : 0;
                 break;
+            case 'follower_count':
+                $this->followedByCount = $value;
+                break;
             case 'edge_owner_to_timeline_media':
                 $this->initMedia($array[$prop]);
                 break;


### PR DESCRIPTION
When you use searchAccountsByUsername some properties are not pupulated as expected by the raw data return from Instagram.