### PR TITLE
Remove the null value from the $cache parameter

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -47,7 +47,7 @@ class Instagram
     /**
      * @param string $username
      * @param string $password
-     * @param CacheInterface|null $cache
+     * @param CacheInterface $cache
      *
      * @return Instagram
      */


### PR DESCRIPTION
The $cache parameter can't be null value and must be an instance of Psr\SimpleCache\CacheInterface.