### PR TITLE
Update Media.php

### DIFF
--- a/src/InstagramScraper/Model/Media.php
+++ b/src/InstagramScraper/Model/Media.php
@@ -216,7 +216,7 @@ class Media extends AbstractModel
         while ($id > 0) {
             $remainder = $id % 64;
             $id = ($id - $remainder) / 64;
-            $code = $alphabet{$remainder} . $code;
+            $code = $alphabet[$remainder] . $code;
         };
         return $code;
     }


### PR DESCRIPTION
Deprecated: Array and string offset access syntax with curly braces is deprecated in PHP 7.4.