### PR TITLE
fix types of exceptions

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -350,7 +350,7 @@ class Instagram
         $userArray = self::extractSharedDataFromBody($response->raw_body);
 
         if (!isset($userArray['entry_data']['ProfilePage'][0]['graphql']['user'])) {
-            throw new InstagramNotFoundException('Account with this username does not exist');
+            throw new InstagramException('Response code is ' . $response->code . '. Body: ' . static::getErrorBody($response->body) . ' Something went wrong. Please report issue.', $response->code);
         }
         return Account::create($userArray['entry_data']['ProfilePage'][0]['graphql']['user']);
     }
@@ -489,7 +489,7 @@ class Instagram
         $userArray = $this->decodeRawBodyToJson($response->raw_body);
 
         if (!isset($userArray['graphql']['user'])) {
-            throw new InstagramNotFoundException('Account with this username does not exist');
+            throw new InstagramException('Response code is ' . $response->code . '. Body: ' . static::getErrorBody($response->body) . ' Something went wrong. Please report issue.', $response->code);
         }
 
         $nodes = $userArray['graphql']['user']['edge_owner_to_timeline_media']['edges'];


### PR DESCRIPTION
I'm not sure whether there is a case when [this line](https://github.com/postaddictme/instagram-php-scraper/blob/924cc5e586bfc0895f331409312f4cdc257b770e/src/InstagramScraper/Instagram.php#L353) is called and the account actually doesn't exist, but I'm sure that there **is** a case when it's called and the account **exists** - it happens when Instagram blocks your IP (see #555 ). Therefore I think it should return generic `InstagramException` instead.

I'm not sure if it works the same way in `getMediasFromFeed()` ([line 492](https://github.com/postaddictme/instagram-php-scraper/blob/924cc5e586bfc0895f331409312f4cdc257b770e/src/InstagramScraper/Instagram.php#L492)) - but I guess it's safer to throw a more broad exception there, too (and keep `InstagramNotFoundException` for 404 HTTP status only).