### PR TITLE
[Hotfix] Correct caption & alt text

### DIFF
--- a/src/InstagramScraper/Model/Media.php
+++ b/src/InstagramScraper/Model/Media.php
@@ -551,7 +551,7 @@ class Media extends AbstractModel
                 $this->caption = $arr[$prop];
                 break;
             case 'accessibility_caption':
-                $this->caption = $value;
+                $this->altText = $value;
                 break;
             case 'video_views':
                 $this->videoViews = $value;


### PR DESCRIPTION
@raiym 
**Before:**
```php
case 'caption':
    $this->caption = $arr[$prop];
    break;
case 'accessibility_caption':
    $this->caption = $value;
    break;
```
**After:**
```php
case 'caption':
    $this->caption = $arr[$prop];
    break;
case 'accessibility_caption':
    $this->altText = $value;
    break;
```