### PR TITLE
Different query_hash for account Medias with location data

### DIFF
--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -8,7 +8,7 @@ class Endpoints
     const LOGIN_URL = 'https://www.instagram.com/accounts/login/ajax/';
     const ACCOUNT_PAGE = 'https://www.instagram.com/{username}';
     const MEDIA_LINK = 'https://www.instagram.com/p/{code}';
-    const ACCOUNT_MEDIAS = 'https://www.instagram.com/graphql/query/?query_hash=42323d64886122307be10013ad2dcc44&variables={variables}';
+    const ACCOUNT_MEDIAS = 'https://www.instagram.com/graphql/query/?query_hash=e769aa130647d2354c40ea6a439bfc08&variables={variables}';
     const ACCOUNT_JSON_INFO = 'https://www.instagram.com/{username}/?__a=1';
     const MEDIA_JSON_INFO = 'https://www.instagram.com/p/{code}/?__a=1';
     const MEDIA_JSON_BY_LOCATION_ID = 'https://www.instagram.com/explore/locations/{{facebookLocationId}}/?__a=1&max_id={{maxId}}';
@@ -183,12 +183,12 @@ class Endpoints
         return $url;
     }
 
-    public static function getLikeUrl($mediaId) 
+    public static function getLikeUrl($mediaId)
     {
         return str_replace('{mediaId}', urlencode($mediaId), static::LIKE_URL);
     }
 
-    public static function getUnlikeUrl($mediaId) 
+    public static function getUnlikeUrl($mediaId)
     {
         return str_replace('{mediaId}', urlencode($mediaId), static::UNLIKE_URL);
     }


### PR DESCRIPTION
I create a PR to fix error in #582 
This new query_hash that I found following XHR calls on ig official site, fix the problem of empty location data on getMediasByUserId function