### PR TITLE
Fix when 'Location' prop is NULL

### DIFF
--- a/src/InstagramScraper/Model/Media.php
+++ b/src/InstagramScraper/Model/Media.php
@@ -573,10 +573,12 @@ class Media extends AbstractModel
                 }
                 break;
             case 'location':
-                $this->locationId = $arr[$prop]['id'] ? $arr[$prop]['id'] : null;
-                $this->locationName = $arr[$prop]['name'] ? $arr[$prop]['name'] : null;
-                $this->locationSlug = $arr[$prop]['slug'] ? $arr[$prop]['slug'] : null;
-                $this->locationAddressJson = isset($arr[$prop]['address_json']) ? $arr[$prop]['address_json'] : null;
+                if(isset($arr[$prop])) {
+                    $this->locationId = $arr[$prop]['id'] ? $arr[$prop]['id'] : null;
+                    $this->locationName = $arr[$prop]['name'] ? $arr[$prop]['name'] : null;
+                    $this->locationSlug = $arr[$prop]['slug'] ? $arr[$prop]['slug'] : null;
+                    $this->locationAddressJson = isset($arr[$prop]['address_json']) ? $arr[$prop]['address_json'] : null;
+                }
                 break;
             case 'user':
                 $this->owner = Account::create($arr[$prop]);


### PR DESCRIPTION
src/InstagramScraper/Model/Media.php line 575

Fix location can be NULL, we get errors for accounts where it's null.