### PR TITLE
Fixed useragent mismatch error

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1568,7 +1568,7 @@ class Instagram
             }
         }
 
-        if (!preg_match('/name="security_code"/', $response->raw_body, $matches)) {
+        if (!preg_match('/"input_name":"security_code"/', $response->raw_body, $matches)) {
             throw new InstagramAuthException('Something went wrong when try two step verification. Please report issue.', $response->code);
         }
 


### PR DESCRIPTION
Fixed the issue mentioned here:

https://github.com/postaddictme/instagram-php-scraper/issues/637

The get user endpoint is now accessible only from the app so I added an android user agent so Instagram will allow getting user info.

This issue also appears on the python version of this library
https://github.com/realsirjoe/instagram-scraper/issues/54