### PR TITLE
Add setCustomCookies method

### DIFF
--- a/examples/setCustomCookies.php
+++ b/examples/setCustomCookies.php
@@ -1,0 +1,29 @@
+<?php
+use InstagramScraper\Exception\InstagramException;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+
+$newCookie = [
+    "ig_did"        =>	"88E6839******C29587D777B",
+    "mid"           =>	"XtFTPg******3hDNk3",
+    "shbid"         =>	"6262",
+    "shbts"         =>	"1594047690****683",
+    "sessionid"     =>	"3640101987****3A25",
+    "csrftoken"     =>	"VeI80i*****0l6ggxd",
+    "ds_user_id"    =>	"36*****872",
+];
+
+$instagram = \InstagramScraper\Instagram::withCredentials($this->instaUsername, $this->instaPassword,new Psr16Adapter('Files') );
+$instagram->setUserAgent('User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:78.0) Gecko/20100101 Firefox/78.0');
+$instagram->setCustomCookies($newCookie);
+$instagram->login();
+$instagram->saveSession();
+
+
+try {
+    $account = $instagram->getAccount('username');
+
+} catch (InstagramException $ex) {
+    echo $ex->getMessage();
+}

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -48,6 +48,7 @@ class Instagram
     private $userSession;
     private $rhxGis = null;
     private $userAgent = 'Mozilla/5.0 (Linux; Android 8.1.0; motorola one Build/OPKS28.63-18-3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 Instagram 72.0.0.21.98 Android (27/8.1.0; 320dpi; 720x1362; motorola; motorola one; deen_sprout; qcom; pt_BR; 132081645)';
+    private $customCookies = null;
 
     /**
      * @param string $username
@@ -318,6 +319,28 @@ class Instagram
         return $medias;
     }
 
+
+    /**
+     *
+     * @return array
+     */
+    public function getCustomCookies()
+    {
+        return $this->customCookies;
+    }
+
+    /**
+     * @param $cookies
+     *
+     * @return array
+     */
+    public function setCustomCookies($cookies)
+    {
+        return $this->customCookies = $cookies;
+    }
+
+
+
     /**
      * We work only on https in this case if we have same cookies on Secure and not - we will choice Secure cookie
      *
@@ -327,6 +350,10 @@ class Instagram
      */
     private function parseCookies($headers)
     {
+        if($this->customCookies){
+            return $this->getCustomCookies();
+        }
+
         $rawCookies = isset($headers['Set-Cookie']) ? $headers['Set-Cookie'] : (isset($headers['set-cookie']) ? $headers['set-cookie'] : []);
 
         if (!is_array($rawCookies)) {


### PR DESCRIPTION
Hi

When you login with multi ip instagram detect and warn you 
You can set your own cookie from firefox to bypass Instagram Bot

Firefox Cookie for Instagram something like this : 

`$newCookie = [
            "ig_did"         =>	"88E68394-AF06-4968-87A4-****",
	     "mid"           =>	"XtFTPgALAAGAoOYvjP_****",
	     "shbid"         =>	"6262",
            "shbts"          =>	"1594047690.0***3",
            "sessionid"    =>	"36401019872%*****5",
            "csrftoken"    =>	"VeI80iDT****xd",
            "ds_user_id"   => "364****872",
        ];`

before use Login method you should set custom cookie : 
$instagram->setCustomCookies($newCookie);
$instagram->login();