### PR TITLE
Fix fatal error <Undefined index: has_next_page>

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1315,6 +1315,15 @@ class Instagram
                 throw new InstagramException('Failed to get followers of account id ' . $accountId . '. The account is private.', static::HTTP_FORBIDDEN);
             }
 
+            $pageInfo = $jsonResponse['data']['user']['edge_followed_by']['page_info'];
+            $lastPagingInfo = $pageInfo;
+            if ($pageInfo['has_next_page']) {
+                $endCursor = $pageInfo['end_cursor'];
+                $hasNextPage = true;
+            } else {
+                $hasNextPage = false;
+            }
+
             foreach ($edgesArray as $edge) {
                 $accounts[] = $edge['node'];
                 $index++;
@@ -1322,11 +1331,8 @@ class Instagram
                     break 2;
                 }
             }
-            $pageInfo = $jsonResponse['data']['user']['edge_followed_by']['page_info'];
-            $lastPagingInfo = $pageInfo;
-            if ($pageInfo['has_next_page']) {
-                $endCursor = $pageInfo['end_cursor'];
-            } else {
+
+            if (!$hasNextPage) {
                 break;
             }
 
@@ -1407,6 +1413,15 @@ class Instagram
                 throw new InstagramException('Failed to get followers of account id ' . $accountId . '. The account is private.', static::HTTP_FORBIDDEN);
             }
 
+            $pageInfo = $jsonResponse['data']['user']['edge_follow']['page_info'];
+            $lastPagingInfo = $pageInfo;
+            if ($pageInfo['has_next_page']) {
+                $endCursor = $pageInfo['end_cursor'];
+                $hasNextPage = true;
+            } else {
+                $hasNextPage = false;
+            }
+
             foreach ($edgesArray as $edge) {
                 $accounts[] = $edge['node'];
                 $index++;
@@ -1415,11 +1430,7 @@ class Instagram
                 }
             }
 
-            $pageInfo = $jsonResponse['data']['user']['edge_follow']['page_info'];
-            $lastPagingInfo = $pageInfo;
-            if ($pageInfo['has_next_page']) {
-                $endCursor = $pageInfo['end_cursor'];
-            } else {
+            if (!$hasNextPage) {
                 break;
             }
 


### PR DESCRIPTION
Fix fatal error
`Undefined index: has_next_page at vendor/raiym/instagram-php-scraper/src/InstagramScraper/Instagram.php:1340`

@raiym This is a hotfix for a fatal error, so we should merge it ASAP. Thank you!