### PR TITLE
Add functions to scrap all followers, following

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1372,7 +1372,8 @@ class Instagram
 
         $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
 
-        if ($jsonResponse['data']['user']['edge_followed_by']['count'] === 0) {
+        $count = $jsonResponse['data']['user']['edge_followed_by']['count'];
+        if ($count === 0) {
             return [];
         }
 
@@ -1389,6 +1390,7 @@ class Instagram
         $pageInfo = $jsonResponse['data']['user']['edge_followed_by']['page_info'];
 
         return [
+            'count' => $count,
             'hasNextPage' => $pageInfo['has_next_page'],
             'nextPage' => $pageInfo['end_cursor'],
             'accounts' => $accounts

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1496,6 +1496,53 @@ class Instagram
     }
 
     /**
+     * @param $accountId
+     * @param int $pageSize
+     * @param string $nextPage
+     *
+     * @return array
+     * @throws InstagramException
+     * @throws InstagramNotFoundException
+     */
+    public function getPaginateAllFollowing($accountId, $pageSize = 20, $nextPage = '')
+    {
+        $response = Request::get(Endpoints::getFollowingJsonLink($accountId, $pageSize, $nextPage),
+            $this->generateHeaders($this->userSession));
+        if ($response->code === static::HTTP_NOT_FOUND) {
+            throw new InstagramNotFoundException('Account with this id doesn\'t exist');
+        }
+        if ($response->code !== static::HTTP_OK) {
+            throw new InstagramException('Response code is ' . $response->code . '. Body: ' . static::getErrorBody($response->body) . ' Something went wrong. Please report issue.', $response->code);
+        }
+
+        $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
+
+        $count = $jsonResponse['data']['user']['edge_follow']['count'];
+        if ($count === 0) {
+            return [];
+        }
+
+        $edgesArray = $jsonResponse['data']['user']['edge_follow']['edges'];
+        if (count($edgesArray) === 0) {
+            throw new InstagramException('Failed to get following of account id ' . $accountId . '. The account is private.', static::HTTP_FORBIDDEN);
+        }
+
+        $accounts = [];
+        foreach ($edgesArray as $edge) {
+            $accounts[] = $edge['node'];
+        }
+
+        $pageInfo = $jsonResponse['data']['user']['edge_follow']['page_info'];
+
+        return [
+            'count' => $count,
+            'hasNextPage' => $pageInfo['has_next_page'],
+            'nextPage' => $pageInfo['end_cursor'],
+            'accounts' => $accounts
+        ];
+    }
+
+    /**
      * @param array $reel_ids - array of instagram user ids
      * @return array
      * @throws InstagramException


### PR DESCRIPTION
We already have `getPaginateFollowers`/ `getPaginateFollowing` but we can't scrap all followers/following with them.
https://github.com/postaddictme/instagram-php-scraper/blob/master/src/InstagramScraper/Instagram.php#L1302
```php
public function getPaginateFollowers($accountId, $count = 20, $pageSize = 20, $delayed = true, $nextPage = '')
{
    //
}
```
https://github.com/postaddictme/instagram-php-scraper/blob/master/src/InstagramScraper/Instagram.php#L1400
```php
public function getPaginateFollowing($accountId, $count = 20, $pageSize = 20, $delayed = true, $nextPage = '')
{
    //
}
```

For these two functions, we must pass `$count` argument (the total number of followers we need to retrieve)

So i added functions to scrap all followers/following:
- Followers: `getPaginateAllFollowers`
- Following: `getPaginateAllFollowing`