### PR TITLE
Add exceptions in case Instagram asks to enter recaptcha or phone number

### DIFF
--- a/src/InstagramScraper/Exception/InstagramChallengeRecaptchaException.php
+++ b/src/InstagramScraper/Exception/InstagramChallengeRecaptchaException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace InstagramScraper\Exception;
+
+class InstagramChallengeRecaptchaException extends InstagramException
+{
+    public function __construct($message = "", $code = 400, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/InstagramScraper/Exception/InstagramChallengeSubmitPhoneNumberException.php
+++ b/src/InstagramScraper/Exception/InstagramChallengeSubmitPhoneNumberException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace InstagramScraper\Exception;
+
+class InstagramChallengeSubmitPhoneNumberException extends InstagramException
+{
+    public function __construct($message = "", $code = 400, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1773,7 +1773,9 @@ class Instagram
             throw new InstagramChallengeSubmitPhoneNumberException('Instagram asked to enter a phone number.', $response->code);
         }
 
-        if (! preg_match('/"input_name":"security_code"/', $response->raw_body, $matches)) {
+        if (! preg_match('/"input_name":"security_code"/', $response->raw_body, $matches)
+            && ! preg_match('/"challengeType":"SelectVerificationMethodForm"/', $response->raw_body, $matches)
+        ) {
             throw new InstagramAuthException('Something went wrong when try two step verification. Please report issue.', $response->code);
         } elseif (! $twoStepVerificator instanceof TwoStepVerificationInterface) {
             throw new InstagramAuthException('$twoStepVerificator must be an instance of TwoStepVerificationInterface.', $response->code);

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1773,11 +1773,8 @@ class Instagram
             throw new InstagramChallengeSubmitPhoneNumberException('Instagram asked to enter a phone number.', $response->code);
         }
 
-        if (! preg_match('/"input_name":"security_code"/', $response->raw_body, $matches)
-            && ! preg_match('/"challengeType":"SelectVerificationMethodForm"/', $response->raw_body, $matches)
-        ) {
-            throw new InstagramAuthException('Something went wrong when try two step verification. Please report issue.', $response->code);
-        } elseif (! $twoStepVerificator instanceof TwoStepVerificationInterface) {
+        // for 2FA case
+        if (! $twoStepVerificator instanceof TwoStepVerificationInterface) {
             throw new InstagramAuthException('$twoStepVerificator must be an instance of TwoStepVerificationInterface.', $response->code);
         }
 
@@ -1799,6 +1796,10 @@ class Instagram
                 $selected_choice = $twoStepVerificator->getVerificationType($choices);
                 $response = Request::post($url, $headers, ['choice' => $selected_choice]);
             }
+        }
+
+        if (!preg_match('/"input_name":"security_code"/', $response->raw_body, $matches)) {
+            throw new InstagramAuthException('Something went wrong when try two step verification. Please report issue.', $response->code);
         }
 
         $security_code = $twoStepVerificator->getSecurityCode();

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1625,9 +1625,11 @@ class Instagram
      * $support_two_step_verification true works only in cli mode - just run login in cli mode - save cookie to file and use in any mode
      *
      * @return array
-     * @throws InstagramException
-     *
      * @throws InstagramAuthException
+     * @throws InstagramChallengeRecaptchaException
+     * @throws InstagramChallengeSubmitPhoneNumberException
+     * @throws InstagramException
+     * @throws \Psr\SimpleCache\InvalidArgumentException
      */
     public function login($force = false, $twoStepVerificator = null)
     {

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1769,6 +1769,8 @@ class Instagram
 
         if (preg_match('/"challengeType":"RecaptchaChallengeForm"/', $response->raw_body, $matches)) {
             throw new InstagramChallengeRecaptchaException('Instagram asked to enter the captcha.', $response->code);
+        } elseif (preg_match('/"challengeType":"SubmitPhoneNumberForm"/', $response->raw_body, $matches)) {
+            throw new InstagramChallengeSubmitPhoneNumberException('Instagram asked to enter a phone number.', $response->code);
         }
 
         if (! preg_match('/"input_name":"security_code"/', $response->raw_body, $matches)) {


### PR DESCRIPTION
- Added `InstagramChallengeRecaptchaException`
- Added `InstagramChallengeSubmitPhoneNumberException`
![image](https://user-images.githubusercontent.com/3295246/91142892-d1c81b00-e6db-11ea-9ffd-7ba968c1df32.png)
![image](https://user-images.githubusercontent.com/3295246/91142970-f6bc8e00-e6db-11ea-82d2-6001509caeec.png)

@raiym 