### PR TITLE
Get threads from direct and usage extends cache interface

### DIFF
--- a/examples/addAndDeleteComment.php
+++ b/examples/addAndDeleteComment.php
@@ -1,9 +1,10 @@
 <?php
 use InstagramScraper\Exception\InstagramException;
+use Phpfastcache\Helper\Psr16Adapter;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 try {
@@ -12,7 +13,7 @@ try {
     $comment = $instagram->addComment($mediaId, 'Text 1');
     // replied to comment
     $instagram->addComment($mediaId, 'Text 2', $comment);
-    
+
     $instagram->deleteComment($mediaId, $comment);
 } catch (InstagramException $ex) {
     echo $ex->getMessage();

--- a/examples/getAccountFollowers.php
+++ b/examples/getAccountFollowers.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', 'path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 sleep(2); // Delay to mimic user
 

--- a/examples/getAccountFollowings.php
+++ b/examples/getAccountFollowings.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', 'path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 sleep(2); // Delay to mimic user
 

--- a/examples/getAccountMediasByUsername.php
+++ b/examples/getAccountMediasByUsername.php
@@ -1,4 +1,6 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
 // If account is public you can query Instagram without auth
@@ -28,6 +30,6 @@ echo "Profile pic url: {$account->getProfilePicUrl()}\n";
 
 
 // If account private you should be subscribed and after auth it will be available
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', 'path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 $medias = $instagram->getMedias('private_account', 100);

--- a/examples/getCurrentTopMediasByLocationId.php
+++ b/examples/getCurrentTopMediasByLocationId.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $medias = $instagram->getCurrentTopMediasByLocationId('1');

--- a/examples/getCurrentTopMediasByTagName.php
+++ b/examples/getCurrentTopMediasByTagName.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $medias = $instagram->getCurrentTopMediasByTagName('youneverknow');

--- a/examples/getHighlights.php
+++ b/examples/getHighlights.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $userId = $instagram->getAccount('instagram')->getId();

--- a/examples/getLocationById.php
+++ b/examples/getLocationById.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 // Location id from facebook

--- a/examples/getMediaByCode.php
+++ b/examples/getMediaByCode.php
@@ -1,9 +1,11 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 // If account is public you can query Instagram without auth
 $instagram = new \InstagramScraper\Instagram();
 
 // If account is private and you subscribed to it, first login
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $media = $instagram->getMediaByCode('BHaRdodBouH');

--- a/examples/getMediaById.php
+++ b/examples/getMediaById.php
@@ -1,11 +1,13 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
 // If account is public you can query Instagram without auth
 $instagram = new \InstagramScraper\Instagram();
 
 // If account is private and you subscribed to it, first login
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $media = $instagram->getMediaById('1270593720437182847');

--- a/examples/getMediaByUrl.php
+++ b/examples/getMediaByUrl.php
@@ -1,11 +1,13 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
 // If account is public you can query Instagram without auth
 $instagram = new \InstagramScraper\Instagram();
 
 // If account is private and you subscribed to it, first login
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $media = $instagram->getMediaByUrl('https://www.instagram.com/p/BHaRdodBouH');

--- a/examples/getMediaComments.php
+++ b/examples/getMediaComments.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', 'path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 // Get media comments by shortcode

--- a/examples/getMediasByLocationId.php
+++ b/examples/getMediasByLocationId.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $medias = $instagram->getMediasByLocationId('1', 20);

--- a/examples/getMediasByTag.php
+++ b/examples/getMediasByTag.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $medias = $instagram->getMediasByTag('youneverknow', 20);

--- a/examples/getPaginateMediasByTag.php
+++ b/examples/getPaginateMediasByTag.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $result = $instagram->getPaginateMediasByTag('zara');

--- a/examples/getSidecarMediaByUrl.php
+++ b/examples/getSidecarMediaByUrl.php
@@ -1,4 +1,6 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
 function printMediaInfo(\InstagramScraper\Model\Media $media, $padding = '') {
@@ -17,7 +19,7 @@ function printMediaInfo(\InstagramScraper\Model\Media $media, $padding = '') {
 $instagram = new \InstagramScraper\Instagram();
 
 // If account is private and you subscribed to it firstly login
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $media = $instagram->getMediaByUrl('https://www.instagram.com/p/BQ0lhTeAYo5');

--- a/examples/getStories.php
+++ b/examples/getStories.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $stories = $instagram->getStories();

--- a/examples/getThreads.php
+++ b/examples/getThreads.php
@@ -1,0 +1,45 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
+$instagram->login();
+$instagram->saveSession();
+
+$threads = $instagram->getThreads(10, 10, 20);
+$thread = $threads[0];
+
+echo "Thread Info:\n";
+echo "Id: {$thread->getId()}\n";
+echo "Title: {$thread->getTitle()}\n";
+echo "Type: {$thread->getType()}\n";
+echo "Read State: {$thread->getReadState()}\n\n";
+
+$items = $thread->getItems();
+$item = $items[0];
+
+echo "Item Info:\n";
+echo "Id: {$item->getId()}\n";
+echo "Type: {$item->getType()}\n";
+echo "Time: {$item->getTime()}\n";
+echo "User ID: {$item->getUserId()}\n";
+echo "Text: {$item->getText()}\n\n";
+
+$reelShare = $item->getReelShare();
+
+echo "Reel Share Info:\n";
+echo "Text: {$reelShare->getText()}\n";
+echo "Type: {$reelShare->getType()}\n";
+echo "Owner Id: {$reelShare->getOwnerId()}\n";
+echo "Mentioned Id: {$reelShare->getMentionedId()}\n\n";
+
+$reelMedia = $reelShare->getMedia();
+
+echo "Reel Media Info:\n";
+echo "Id: {$reelMedia->getId()}\n";
+echo "Caption: {$reelMedia->getCaption()}\n";
+echo "Code: {$reelMedia->getCode()}\n";
+echo "Expiring At: {$reelMedia->getExpiringAt()}\n";
+echo "Image: {$reelMedia->getImage()}\n\n";
+
+// $user = $reelMedia->getUser(); // InstagramScraper\Model\Account
+// $mentions = $reelMedia->getMentions(); // InstagramScraper\Model\Account[]

--- a/examples/getThreads.php
+++ b/examples/getThreads.php
@@ -1,4 +1,6 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
 $instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));

--- a/examples/likeAndUnlikeMedia.php
+++ b/examples/likeAndUnlikeMedia.php
@@ -1,10 +1,10 @@
 <?php
-
+use Phpfastcache\Helper\Psr16Adapter;
 use InstagramScraper\Exception\InstagramException;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 try {

--- a/examples/paginateAccountMediaByUsername.php
+++ b/examples/paginateAccountMediaByUsername.php
@@ -1,9 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
 require __DIR__ . '/../vendor/autoload.php';
 
-
 // getPaginateMedias() works with and without authentication
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', '/path/to/cache/folder');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 $result = $instagram->getPaginateMedias('kevin');

--- a/examples/searchAccountsByUsername.php
+++ b/examples/searchAccountsByUsername.php
@@ -1,7 +1,9 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', 'path/to/cache/folder/');
+$instagram = \InstagramScraper\Instagram::withCredentials('username', 'password', new Psr16Adapter('Files'));
 $instagram->login();
 
 

--- a/examples/setCustomCookies.php
+++ b/examples/setCustomCookies.php
@@ -1,4 +1,5 @@
 <?php
+use Phpfastcache\Helper\Psr16Adapter;
 use InstagramScraper\Exception\InstagramException;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -14,7 +15,7 @@ $newCookie = [
     "ds_user_id"    =>	"36*****872",
 ];
 
-$instagram = \InstagramScraper\Instagram::withCredentials($this->instaUsername, $this->instaPassword,new Psr16Adapter('Files') );
+$instagram = \InstagramScraper\Instagram::withCredentials($this->instaUsername, $this->instaPassword, new Psr16Adapter('Files'));
 $instagram->setUserAgent('User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:78.0) Gecko/20100101 Firefox/78.0');
 $instagram->setCustomCookies($newCookie);
 $instagram->login();

--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -35,6 +35,7 @@ class Endpoints
     const DELETE_COMMENT_URL = 'https://www.instagram.com/web/comments/{mediaId}/delete/{commentId}/';
     const ACCOUNT_MEDIAS2 = 'https://www.instagram.com/graphql/query/?query_id=17880160963012870&id={{accountId}}&first=10&after=';
     const HIGHLIGHT_URL = 'https://www.instagram.com/graphql/query/?query_hash=c9100bf9110dd6361671f113dd02e7d6&variables={"user_id":"{userId}","include_chaining":false,"include_reel":true,"include_suggested_users":false,"include_logged_out_extras":false,"include_highlight_reels":true,"include_live_status":false}';
+    const THREADS_URL = 'https://www.instagram.com/direct_v2/web/inbox/?persistentBadging=true&folder=&limit={limit}&thread_message_limit={messageLimit}&cursor={cursor}';
 
     // Look alike??
     const URL_SIMILAR = 'https://www.instagram.com/graphql/query/?query_id=17845312237175864&id=4663052';
@@ -215,5 +216,16 @@ class Endpoints
     public static function getHighlightUrl($id)
     {
         return str_replace('{userId}', urlencode($id), static::HIGHLIGHT_URL);
+    }
+
+    public static function getThreadsUrl($limit, $messageLimit, $cursor)
+    {
+        $url = static::THREADS_URL;
+
+        $url = str_replace('{limit}', $limit, $url);
+        $url = str_replace('{messageLimit}', $messageLimit, $url);
+        $url = str_replace('{cursor}', $cursor, $url);
+
+        return $url;
     }
 }

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -60,7 +60,7 @@ class Instagram
      *
      * @return Instagram
      */
-    public static function withCredentials($username, $password, CacheInterface $cache)
+    public static function withCredentials($username, $password, $cache)
     {
         static::$instanceCache = $cache;
         $instance = new self();

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -17,6 +17,7 @@ use InstagramScraper\Model\Location;
 use InstagramScraper\Model\Media;
 use InstagramScraper\Model\Story;
 use InstagramScraper\Model\Tag;
+use InstagramScraper\Model\Thread;
 use InstagramScraper\Model\UserStories;
 use InstagramScraper\Model\Highlight;
 use InstagramScraper\TwoStepVerification\ConsoleVerification;
@@ -39,6 +40,8 @@ class Instagram
     const PAGING_TIME_LIMIT_SEC = 1800; // 30 mins time limit on operations that require multiple requests
     const PAGING_DELAY_MINIMUM_MICROSEC = 1000000; // 1 sec min delay to simulate browser
     const PAGING_DELAY_MAXIMUM_MICROSEC = 3000000; // 3 sec max delay to simulate browser
+
+    const X_IG_APP_ID = '936619743392459';
 
     /** @var CacheInterface $instanceCache */
     private static $instanceCache = null;
@@ -1997,5 +2000,78 @@ class Instagram
             $highlights[] = Highlight::create($highlight_reel['node']);
         }
         return $highlights;
+    }
+
+    /**
+     * @param int $limit
+     * @param int $messageLimit
+     * @param string|null $cursor
+     *
+     * @return array
+     * @throws InstagramException
+     */
+    public function getPaginateThreads($limit = 10, $messageLimit = 10, $cursor = null)
+    {
+        $response = Request::get(
+            Endpoints::getThreadsUrl($limit, $messageLimit, $cursor),
+            array_merge(
+                ['x-ig-app-id' => self::X_IG_APP_ID],
+                $this->generateHeaders($this->userSession)
+            )
+        );
+
+        if ($response->code !== static::HTTP_OK) {
+            throw new InstagramException('Response code is ' . $response->code . '. Body: ' . static::getErrorBody($response->body) . ' Something went wrong. Please report issue.');
+        }
+
+        $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
+
+        if (!isset($jsonResponse['status']) || $jsonResponse['status'] !== 'ok') {
+            throw new InstagramException('Response code is not equal 200. Something went wrong. Please report issue.');
+        }
+
+        if (!isset($jsonResponse['inbox']['threads']) || empty($jsonResponse['inbox']['threads'])) {
+            return [];
+        }
+
+        $threads = [];
+
+        foreach ($jsonResponse['inbox']['threads'] as $jsonThread) {
+            $threads[] = Thread::create($jsonThread);
+        }
+
+        return [
+            'hasOlder' => (bool) $jsonResponse['inbox']['has_older'],
+            'oldestCursor' => isset($jsonResponse['inbox']['oldest_cursor']) ? $jsonResponse['inbox']['oldest_cursor'] : null,
+            'threads' => $threads,
+        ];
+    }
+
+    /**
+     * @param int $count
+     * @param int $limit
+     * @param int $messageLimit
+     *
+     * @return Thread[]
+     * @throws InstagramException
+     */
+    public function getThreads($count = 10, $limit = 10, $messageLimit = 10)
+    {
+        $threads = [];
+        $cursor = null;
+
+        while (count($threads) < $count) {
+            $result = $this->getPaginateThreads($limit, $messageLimit, $cursor);
+
+            $threads = array_merge($threads, $result['threads']);
+
+            if (!$result['hasOlder'] || !$result['oldestCursor']) {
+                break;
+            }
+
+            $cursor = $result['oldestCursor'];
+        }
+
+        return $threads;
     }
 }

--- a/src/InstagramScraper/Model/ReelMedia.php
+++ b/src/InstagramScraper/Model/ReelMedia.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace InstagramScraper\Model;
+
+/**
+ * Class Media
+ * @package InstagramScraper\Model
+ */
+class ReelMedia extends AbstractModel
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $caption;
+
+    /**
+     * @var string
+     */
+    protected $code;
+
+    /**
+     * @var int
+     */
+    protected $expiringAt;
+
+    /**
+     * @var string
+     */
+    protected $image;
+
+    /**
+     * @var Account
+     */
+    protected $user;
+
+    /**
+     * @var Account[]
+     */
+    protected $mentions;
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCaption()
+    {
+        return $this->caption;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpiringAt()
+    {
+        return $this->expiringAt;
+    }
+
+    /**
+     * @return Account[]
+     */
+    public function getMentions()
+    {
+        return $this->mentions;
+    }
+
+    /**
+     * @return Account
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * @param $value
+     * @param $prop
+     * @param $arr
+     */
+    protected function initPropertiesCustom($value, $prop, $arr)
+    {
+        switch ($prop) {
+            case 'id':
+                $this->id = $value;
+                break;
+            case 'caption':
+                $this->caption = isset($arr[$prop]['text']) ? $arr[$prop]['text'] : null;
+                break;
+            case 'code':
+                $this->code = $value;
+                break;
+            case 'expiring_at':
+                $this->expiringAt = (int)$value;
+                break;
+            case 'reel_mentions':
+                foreach ($arr[$prop] as $mention) {
+                    if (!$mention['user']) {
+                        continue;
+                    }
+
+                    $this->mentions[] = Account::create($mention['user']);
+                }
+                break;
+            case 'user':
+                $this->user = Account::create($arr[$prop]);
+                break;
+            case 'image_versions2':
+                foreach ($arr[$prop]['candidates'] as $candidate) {
+                    if (!$candidate['url']) {
+                        continue;
+                    }
+
+                    $this->image = $candidate['url'];
+                    break;
+                }
+                break;
+        }
+    }
+}

--- a/src/InstagramScraper/Model/ReelMedia.php
+++ b/src/InstagramScraper/Model/ReelMedia.php
@@ -76,11 +76,11 @@ class ReelMedia extends AbstractModel
     }
 
     /**
-     * @return Account[]
+     * @return string
      */
-    public function getMentions()
+    public function getImage()
     {
-        return $this->mentions;
+        return $this->image;
     }
 
     /**
@@ -92,11 +92,11 @@ class ReelMedia extends AbstractModel
     }
 
     /**
-     * @return string
+     * @return Account[]
      */
-    public function getImage()
+    public function getMentions()
     {
-        return $this->image;
+        return $this->mentions;
     }
 
     /**

--- a/src/InstagramScraper/Model/ReelShare.php
+++ b/src/InstagramScraper/Model/ReelShare.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace InstagramScraper\Model;
+
+/**
+ * Class Media
+ * @package InstagramScraper\Model
+ */
+class ReelShare extends AbstractModel
+{
+    /**
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var int
+     */
+    protected $mentionedId;
+
+    /**
+     * @var int
+     */
+    protected $ownerId;
+
+    /**
+     * @var ReelMedia
+     */
+    protected $media;
+
+    /**
+     * @return string
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMentionedId()
+    {
+        return $this->mentionedId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOwnerId()
+    {
+        return $this->ownerId;
+    }
+
+    /**
+     * @return ReelMedia
+     */
+    public function getMedia()
+    {
+        return $this->media;
+    }
+
+    /**
+     * @param $value
+     * @param $prop
+     * @param $arr
+     */
+    protected function initPropertiesCustom($value, $prop, $arr)
+    {
+        switch ($prop) {
+            case 'text':
+                $this->text = $value;
+                break;
+            case 'type':
+                $this->type = $value;
+                break;
+            case 'mentioned_user_id':
+                $this->mentionedId = (int) $value;
+                break;
+            case 'reel_owner_id':
+                $this->ownerId = (int) $value;
+                break;
+            case 'media':
+                $this->media = ReelMedia::create($arr[$prop]);
+                break;
+        }
+    }
+}

--- a/src/InstagramScraper/Model/Thread.php
+++ b/src/InstagramScraper/Model/Thread.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace InstagramScraper\Model;
+
+/**
+ * Class Media
+ * @package InstagramScraper\Model
+ */
+class Thread extends AbstractModel
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var boolean
+     */
+    protected $archived;
+
+    /**
+     * @var boolean
+     */
+    protected $hasNewer;
+
+    /**
+     * @var boolean
+     */
+    protected $hasOlder;
+
+    /**
+     * @var boolean
+     */
+    protected $isGroup;
+
+    /**
+     * @var boolean
+     */
+    protected $isPin;
+
+    /**
+     * @var boolean
+     */
+    protected $readState;
+
+    /**
+     * @var array
+     */
+    protected $items = [];
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isArchived()
+    {
+        return $this->archived;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function hasNewer()
+    {
+        return $this->hasNewer;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function hasOlder()
+    {
+        return $this->hasOlder;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isGroup()
+    {
+        return $this->isGroup;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isPin()
+    {
+        return $this->isPin;
+    }
+
+    /**
+     * @return ThreadItem[]
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getReadState()
+    {
+        return $this->readState;
+    }
+
+    /**
+     * @param $value
+     * @param $prop
+     * @param $arr
+     */
+    protected function initPropertiesCustom($value, $prop, $arr)
+    {
+        switch ($prop) {
+            case 'thread_id':
+                $this->id = $value;
+                break;
+            case 'thread_title':
+                $this->title = $value;
+                break;
+            case 'thread_type':
+                $this->type = $value;
+                break;
+            case 'archived':
+                $this->archived = (bool)$value;
+                break;
+            case 'has_newer':
+                $this->hasNewer = (bool)$value;
+                break;
+            case 'has_older':
+                $this->hasOlder = (bool)$value;
+                break;
+            case 'is_group':
+                $this->isGroup = (bool)$value;
+                break;
+            case 'is_pin':
+                $this->isPin = (bool)$value;
+                break;
+            case 'read_state':
+                $this->readState = (bool)$value;
+                break;
+            case 'items':
+                foreach ($arr[$prop] as $item) {
+                    $this->items[] = ThreadItem::create($item);
+                }
+                break;
+        }
+    }
+}

--- a/src/InstagramScraper/Model/Thread.php
+++ b/src/InstagramScraper/Model/Thread.php
@@ -123,19 +123,19 @@ class Thread extends AbstractModel
     }
 
     /**
-     * @return ThreadItem[]
-     */
-    public function getItems()
-    {
-        return $this->items;
-    }
-
-    /**
      * @return boolean
      */
     public function getReadState()
     {
         return $this->readState;
+    }
+
+    /**
+     * @return ThreadItem[]
+     */
+    public function getItems()
+    {
+        return $this->items;
     }
 
     /**

--- a/src/InstagramScraper/Model/ThreadItem.php
+++ b/src/InstagramScraper/Model/ThreadItem.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace InstagramScraper\Model;
+
+/**
+ * Class Media
+ * @package InstagramScraper\Model
+ */
+class ThreadItem extends AbstractModel
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * @var int
+     */
+    protected $time;
+
+    /**
+     * @var string
+     */
+    protected $userId;
+
+    /**
+     * @var object
+     */
+    protected $reelShare;
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * @return object
+     */
+    public function getReelShare()
+    {
+        return $this->reelShare;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTime()
+    {
+        return $this->time;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+
+    /**
+     * @param $value
+     * @param $prop
+     * @param $arr
+     */
+    protected function initPropertiesCustom($value, $prop, $arr)
+    {
+        switch ($prop) {
+            case 'item_id':
+                $this->id = $value;
+                break;
+            case 'item_type':
+                $this->type = $value;
+                break;
+            case 'text':
+                if ($arr['item_type'] === 'text') {
+                    $this->text = $value;
+                }
+                break;
+            case 'reel_share':
+                if ($arr['item_type'] === 'reel_share') {
+                    $this->reelShare = ReelShare::create($arr[$prop]);
+                }
+                break;
+            case 'timestamp':
+                $this->time = (int) ($value / 1000000);
+                break;
+            case 'user_id':
+                $this->userId = $value;
+                break;
+        }
+    }
+}

--- a/src/InstagramScraper/Model/ThreadItem.php
+++ b/src/InstagramScraper/Model/ThreadItem.php
@@ -34,7 +34,7 @@ class ThreadItem extends AbstractModel
     protected $userId;
 
     /**
-     * @var object
+     * @var ReelShare
      */
     protected $reelShare;
 
@@ -63,14 +63,6 @@ class ThreadItem extends AbstractModel
     }
 
     /**
-     * @return object
-     */
-    public function getReelShare()
-    {
-        return $this->reelShare;
-    }
-
-    /**
      * @return int
      */
     public function getTime()
@@ -84,6 +76,14 @@ class ThreadItem extends AbstractModel
     public function getUserId()
     {
         return $this->userId;
+    }
+
+    /**
+     * @return ReelShare
+     */
+    public function getReelShare()
+    {
+        return $this->reelShare;
     }
 
     /**


### PR DESCRIPTION
- Can use extends cache, for example laravel cache (/Illuminate/Contracts/Cache/Repository)
- Can get direct threads with items
- Add example getThreads
- Fix all examples (third arguments in withCredentials method)