### PR TITLE
Fixed Instagram::getFeed() and added an example

### DIFF
--- a/examples/getFeed.php
+++ b/examples/getFeed.php
@@ -1,0 +1,15 @@
+<?php
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+use InstagramScraper\Instagram;
+use Phpfastcache\Helper\Psr16Adapter;
+
+$instagram  = Instagram::withCredentials('login', 'password', new Psr16Adapter('Files'));
+$instagram->login();
+$instagram->saveSession();
+
+$posts  = $instagram->getFeed();
+
+foreach ($posts as $post){
+    echo $post->getImageHighResolutionUrl()."\n";
+}

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -302,7 +302,7 @@ class Instagram
      */
     public function getFeed()
     {
-        $response = Request::get(Endpoints::getFeedJson(),
+        $response = Request::get(Endpoints::USER_FEED,
             $this->generateHeaders($this->userSession));
 
         if ($response->code === static::HTTP_NOT_FOUND) {


### PR DESCRIPTION
Fixed Instagram::getFeed() (issue #595) and added an example (issue #700)