### PR TITLE
Update withCredentials() function on Instagram.php

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -60,14 +60,20 @@ class Instagram
     /**
      * @param string $username
      * @param string $password
-     * @param CacheInterface $cache
+     * @param null $path
      *
      * @return Instagram
      */
-    public static function withCredentials($username, $password)
+    public static function withCredentials($username, $password, $path = null)
     {
         if(static::$instanceCache == null){
-            static::$instanceCache = new Psr16Adapter('Files');
+            if (!is_null($path) && is_string($path)) {
+                static::$instanceCache = new Psr16Adapter('Files', new \Phpfastcache\Config\ConfigurationOption([
+                    'path' => $path
+                ]));
+            }else{
+                static::$instanceCache = new Psr16Adapter('Files');
+            }
         }
         $instance = new self();
         $instance->sessionUsername = $username;

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -27,6 +27,7 @@ use Psr\SimpleCache\CacheInterface;
 use stdClass;
 use Unirest\Request;
 use Unirest\Response;
+use Phpfastcache\Helper\Psr16Adapter;
 
 class Instagram
 {
@@ -63,9 +64,11 @@ class Instagram
      *
      * @return Instagram
      */
-    public static function withCredentials($username, $password, $cache)
+    public static function withCredentials($username, $password)
     {
-        static::$instanceCache = $cache;
+        if(static::$instanceCache == null){
+            static::$instanceCache = new Psr16Adapter('Files');
+        }
         $instance = new self();
         $instance->sessionUsername = $username;
         $instance->sessionPassword = $password;


### PR DESCRIPTION
We need check our `static::$instanceCache` so that is null or has value, if it's null we can make `new Psr16Adapter('Files')` request, otherwise we don't need that, to prevent `Calling many times CacheManager::getInstance() for already instanced drivers` Error.

Sample Error:
> [Files] Calling many times CacheManager::getInstance() for already instanced drivers is a bad practice and have a significant impact on performances.
> See https://github.com/PHPSocialNetwork/phpfastcache/wiki/[V5]-Why-calling-getInstance%28%29-each-time-is-a-bad-practice-%3F {"exception":"[object] (ErrorException(code: 0): [Files] Calling many times CacheManager::getInstance() for already instanced drivers is a bad practice and have a significant impact on performances.
> See https://github.com/PHPSocialNetwork/phpfastcache/wiki/[V5]-Why-calling-getInstance%28%29-each-time-is-a-bad-practice-%3F at /var/www/html/dev/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/CacheManager.php:196)



Also for make login process we should remove third parameter like this: 


`$instagram = \InstagramScraper\Instagram::withCredentials($username, $password);`