### PR TITLE
getPaginateFollowing pagination fix

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1457,7 +1457,7 @@ class Instagram
 
         $index = 0;
         $accounts = [];
-        $endCursor = '';
+        $endCursor = $nextPage;
         $lastPagingInfo = [];
 
         if ($count < $pageSize) {


### PR DESCRIPTION
The $endCursor inside getPaginateFollowing() line no: 1460 was empty changed to $nextPage