### PR TITLE
EmailVerification.php bug fix

### DIFF
--- a/examples/twoStepAutoVerification/EmailVerification.php
+++ b/examples/twoStepAutoVerification/EmailVerification.php
@@ -76,7 +76,8 @@ class EmailVerification implements TwoStepVerificationInterface
 
     private function getMaskedEmail()
     {
-        $mail = explode('@', $this->email);
+        $mail = strtolower($this->email);
+        $mail = explode('@', $mail);
         $mail[0] = $mail[0][0]
             . \str_repeat('*', min(strlen($mail[0]) - 2,7))
             . $mail[0][strlen($mail[0]) - 1];


### PR DESCRIPTION
Instagram masks email in lower case. 
Therefore, an email that has capital letters was incorrectly masked by `EmailVerification ::getMaskedEmail()`. Because of this `InstagramAuthException` throws. 
This pull request fix this issue.