### PR TITLE
Fix top location

### DIFF
--- a/examples/getCurrentTopMediasByLocationId.php
+++ b/examples/getCurrentTopMediasByLocationId.php
@@ -24,3 +24,7 @@ echo "Id: {$account->getId()}\n";
 echo "Username: {$account->getUsername()}\n";
 echo "Full name: {$account->getFullName()}\n";
 echo "Profile pic url: {$account->getProfilePicUrl()}\n";
+
+echo "<br>";
+echo "Location Name: {$media->getLocationName()}\n";
+echo "Location Slug: {$media->getLocationSlug()}\n";

--- a/examples/getCurrentTopMediasByLocationId.php
+++ b/examples/getCurrentTopMediasByLocationId.php
@@ -1,30 +1,34 @@
 <?php
+ini_set('display_errors', 1);ini_set('display_startup_errors', 1);error_reporting(E_ALL);
 use Phpfastcache\Helper\Psr16Adapter;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'username', 'password', new Psr16Adapter('Files'));
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'user', 'passwd', new Psr16Adapter('Files'));
 $instagram->login();
 
-$medias = $instagram->getCurrentTopMediasByLocationId('1');
+$medias = $instagram->getCurrentTopMediasByLocationId('116231');
 $media = $medias[0];
-echo "Media info:\n";
-echo "Id: {$media->getId()}\n";
-echo "Shortcode: {$media->getShortCode()}\n";
-echo "Created at: {$media->getCreatedTime()}\n";
-echo "Caption: {$media->getCaption()}\n";
+
+
+$seperator = PHP_SAPI === 'cli' ? "\n" : "<br>\n";
+echo "Media info:$seperator";
+echo "Id: {$media->getId()}$seperator";
+echo "Shortcode: {$media->getShortCode()}$seperator";
+echo "Created at: {$media->getCreatedTime()}$seperator";
+echo "Caption: {$media->getCaption()}$seperator";
 echo "Number of comments: {$media->getCommentsCount()}";
 echo "Number of likes: {$media->getLikesCount()}";
 echo "Get link: {$media->getLink()}";
 echo "High resolution image: {$media->getImageHighResolutionUrl()}";
 echo "Media type (video or image): {$media->getType()}";
 $account = $media->getOwner();
-echo "Account info:\n";
-echo "Id: {$account->getId()}\n";
-echo "Username: {$account->getUsername()}\n";
-echo "Full name: {$account->getFullName()}\n";
-echo "Profile pic url: {$account->getProfilePicUrl()}\n";
+echo "Account info:$seperator";
+echo "Id: {$account->getId()}$seperator";
+echo "Username: {$account->getUsername()}$seperator";
+echo "Full name: {$account->getFullName()}$seperator";
+echo "Profile pic url: {$account->getProfilePicUrl()}$seperator";
 
 echo "<br>";
-echo "Location Name: {$media->getLocationName()}\n";
-echo "Location Slug: {$media->getLocationSlug()}\n";
+echo "Location Name: {$media->getLocationName()}$seperator";
+echo "Location Slug: {$media->getLocationSlug()}$seperator";

--- a/examples/getMediasByLocationId.php
+++ b/examples/getMediasByLocationId.php
@@ -1,26 +1,33 @@
 <?php
+ini_set('display_errors', 1);ini_set('display_startup_errors', 1);error_reporting(E_ALL);
 use Phpfastcache\Helper\Psr16Adapter;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'username', 'password', new Psr16Adapter('Files'));
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'user', 'passwd', new Psr16Adapter('Files'));
 $instagram->login();
 
-$medias = $instagram->getMediasByLocationId('1', 20);
+$medias = $instagram->getMediasByLocationId('116231', 20);
 $media = $medias[0];
-echo "Media info:\n";
-echo "Id: {$media->getId()}\n";
-echo "Shortcode: {$media->getShortCode()}\n";
-echo "Created at: {$media->getCreatedTime()}\n";
-echo "Caption: {$media->getCaption()}\n";
+
+$seperator = PHP_SAPI === 'cli' ? "$\n" : "<br>\n";
+echo "Media info:$seperator";
+echo "Id: {$media->getId()}$seperator";
+echo "Shortcode: {$media->getShortCode()}$seperator";
+echo "Created at: {$media->getCreatedTime()}$seperator";
+echo "Caption: {$media->getCaption()}$seperator";
 echo "Number of comments: {$media->getCommentsCount()}";
 echo "Number of likes: {$media->getLikesCount()}";
 echo "Get link: {$media->getLink()}";
 echo "High resolution image: {$media->getImageHighResolutionUrl()}";
 echo "Media type (video or image): {$media->getType()}";
 $account = $media->getOwner();
-echo "Account info:\n";
-echo "Id: {$account->getId()}\n";
-echo "Username: {$account->getUsername()}\n";
-echo "Full name: {$account->getFullName()}\n";
-echo "Profile pic url: {$account->getProfilePicUrl()}\n";
+echo "Account info:$seperator";
+echo "Id: {$account->getId()}$seperator";
+echo "Username: {$account->getUsername()}$seperator";
+echo "Full name: {$account->getFullName()}$seperator";
+echo "Profile pic url: {$account->getProfilePicUrl()}$seperator";
+
+echo "<br>";
+echo "Location Name: {$media->getLocationName()}$seperator";
+echo "Location Slug: {$media->getLocationSlug()}$seperator";

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1147,8 +1147,14 @@ class Instagram
             return $toReturn;
         }
 
+        $slug = $arr['graphql']['location']['slug'];
+        $name = $arr['graphql']['location']['name'];
+        $rvd_i = 0;
         foreach ($nodes as $mediaArray) {
-            $medias[] = Media::create($mediaArray['node']);
+            $medias[$rvd_i] = Media::create($mediaArray['node']);
+            $medias[$rvd_i] -> setLocationName($name);
+            $medias[$rvd_i] -> setLocationSlug($slug);
+            $rvd_i++;
         }
 
         $maxId = $arr['graphql']['location']['edge_location_to_media']['page_info']['end_cursor'];
@@ -1213,12 +1219,20 @@ class Instagram
         }
         $this->parseCookies($response->headers);
         $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
-        $nodes = $jsonResponse['location']['top_posts']['nodes'];
+        $nodes = $jsonResponse['graphql']['location']['edge_location_to_top_posts']['edges'];
         $medias = [];
+
+        $slug = $jsonResponse['graphql']['location']['slug'];
+        $name = $jsonResponse['graphql']['location']['name'];
+        $rvd_i=0;
         foreach ($nodes as $mediaArray) {
-            $medias[] = Media::create($mediaArray);
-        }
-        return $medias;
+            $medias[$rvd_i] = Media::create($mediaArray['node']);
+            $medias[$rvd_i] -> setLocationName($name);
+            $medias[$rvd_i] -> setLocationSlug($slug);
+            $rvd_i++;
+          }
+
+      return $medias;
     }
 
     /**
@@ -1247,11 +1261,17 @@ class Instagram
             $this->parseCookies($response->headers);
             $arr = $this->decodeRawBodyToJson($response->raw_body);
             $nodes = $arr['graphql']['location']['edge_location_to_media']['edges'];
+
+            $slug = $arr['graphql']['location']['slug'];
+            $name = $arr['graphql']['location']['name'];
+            
             foreach ($nodes as $mediaArray) {
                 if ($index === $quantity) {
                     return $medias;
                 }
                 $medias[] = Media::create($mediaArray['node']);
+                $medias[$index] -> setLocationName($name);
+                $medias[$index] -> setLocationSlug($slug);
                 $index++;
             }
             if (empty($nodes)) {

--- a/src/InstagramScraper/Model/Media.php
+++ b/src/InstagramScraper/Model/Media.php
@@ -516,6 +516,21 @@ class Media extends AbstractModel
     }
 
     /**
+     * @param string
+     */
+    public function setLocationName($name)
+    {
+        $this->locationName = $name;
+    }
+    /**
+     * @param string
+     */
+    public function setLocationSlug($slug)
+    {
+        $this->locationSlug = $slug;
+    }
+
+    /**
      * @param $value
      * @param $prop
      */


### PR DESCRIPTION
Apperently Instagram changed the API structure.
- Top media is now in:  ['graphql']['location']['edge_location_to_top_posts']['edges'];
   -> this location was already present in the other location based functions.

- Location Slug and Location Name are now on location level (no longer on edge/node level)
  - added setLocationSlug and setLocationName functions in Media model
  - added a call to the set function in Instagram.php:
    - getCurrentTopMedabyLocationId()
    - getMedabyLocationId()
    - getPaginateMedabyLocationId()

