### PR TITLE
Paginate feed user stories

### DIFF
--- a/examples/getPaginateFeed.php
+++ b/examples/getPaginateFeed.php
@@ -21,7 +21,7 @@ use Phpfastcache\Helper\Psr16Adapter;
 require __DIR__ . '/../vendor/autoload.php';
 
 $seperator = PHP_SAPI === 'cli' ? "\n" : "<br>\n";
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'ricdijk', '@leusdeN2020', new Psr16Adapter('Files'));
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'user', 'passwd', new Psr16Adapter('Files'));
 $instagram->login();
 $instagram->saveSession(3600*24);
 

--- a/examples/getPaginateFeed.php
+++ b/examples/getPaginateFeed.php
@@ -21,7 +21,7 @@ use Phpfastcache\Helper\Psr16Adapter;
 require __DIR__ . '/../vendor/autoload.php';
 
 $seperator = PHP_SAPI === 'cli' ? "\n" : "<br>\n";
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'user', 'passwd', new Psr16Adapter('Files'));
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'ricdijk', '@leusdeN2020', new Psr16Adapter('Files'));
 $instagram->login();
 $instagram->saveSession(3600*24);
 
@@ -84,8 +84,8 @@ function display_story($userStories)
     echo "${seperator}First userStory expiringAt     :  " . gmdate("Y-m-d H:i:s", $userStories[0]->getExpiringAt());
     echo " - " . floor(($userStories[0]->getExpiringAt()-time())/3600) . "h";
     echo " " . floor((($userStories[0]->getExpiringAt()-time())%3600)/60) . "m ";
-    echo "${seperator}First userStory last mutation:  " . gmdate("Y-m-d H:i:s", $userStories[0]->getLastMutationData());
-    echo " - " . floor(($userStories[0]->getLastMutationData()-time())/3600) . "h";
+    echo "${seperator}First userStory last mutation:  " . gmdate("Y-m-d H:i:s", $userStories[0]->getLastMutatedAt());
+    echo " - " . floor(($userStories[0]->getLastMutatedAt()-time())/3600) . "h";
 
     echo "${seperator}First userStory user Id:  " . $userStories[0]->getOwner()->getId();
     echo "${seperator}First userStory user Name:  " . $userStories[0]->getOwner()->getUsername();

--- a/examples/getPaginateFeed.php
+++ b/examples/getPaginateFeed.php
@@ -1,0 +1,96 @@
+<?php
+ini_set('display_errors', 1);ini_set('display_startup_errors', 1);error_reporting(E_ALL);
+$seperator = PHP_SAPI === 'cli' ? "\n" : "\n<br>";
+
+if (PHP_SAPI === 'cli') {
+  $seperator = "\n";
+  $c1 = '';
+  $c2 = '';
+  $c3 = '';
+  $cend = '';
+}
+else {
+  $seperator = "\n";
+  $c1 = '<label style="color:red;">';
+  $c2 = '<label style="color:green;">';
+  $c3 = '<label style="color:blue;">';
+  $cend = '</label>';
+}
+use Phpfastcache\Helper\Psr16Adapter;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$seperator = PHP_SAPI === 'cli' ? "\n" : "<br>\n";
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'ricdijk', '@leusdeN2020', new Psr16Adapter('Files'));
+$instagram->login();
+$instagram->saveSession(3600*24);
+
+
+// getFeed has 4 arguments:
+// - Nr of medias
+// - maxId (cursor)
+// - nr of comments
+// - nr of likes => dows not seem to do anything
+$medias = $instagram->getFeed(50,'',6,4);
+echo "${c1}Test getFeed():${cend}";
+display_media($medias);
+echo "${seperator}${seperator}";
+
+
+echo "${seperator}==========================================================================================";
+echo "${seperator}${c1}Test getPaginateFeed():${cend}";
+$maxId       = null;
+$hasNextPage = true;
+$count_fetch = 0;
+while ($hasNextPage)
+{
+  $count_fetch++;
+  if ($count_fetch>3) break;
+
+  $arr = $instagram->getPaginateFeed(10, $maxId, 6, 4);
+  $maxId            = $arr['maxId'];
+  $hasNextPage      = $arr['hasNextPage'];
+
+  echo "${seperator}+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++";
+  echo "${seperator}${c2}Fetch page: " . $count_fetch."${cend}";
+  echo "${seperator}";
+  echo "${seperator}Media Count: " . $arr['media_count'];
+  echo ", Storie Count: " . $arr['storie_count'];
+  display_media($arr['medias']);
+  echo "${seperator}................................................................................";
+  display_story($arr['userStories']);
+  echo "${seperator}";
+
+}
+
+function display_media($medias)
+{
+  global $seperator, $c1, $c2, $c3, $cend;
+  echo "${seperator}Nr of ${c3}media${cend} page: ".count($medias);
+  echo "${seperator}First media Id     :  " . $medias[0]->getId();
+  echo "${seperator}First media Creates:  " . $medias[0]->getCreatedTime();
+  echo "${seperator}First media Caption:  " . $medias[0]->getCaption();
+
+  if (PHP_SAPI === 'cli') echo "${seperator}First media image:  " . $medias[0]->getImageHighResolutionUrl();
+  else echo "${seperator}<img height=100 src='" . $medias[0]->getImageHighResolutionUrl() . "'>\n";
+}
+
+function display_story($userStories)
+{
+  global $seperator, $c1, $c2, $c3, $cend;
+  echo "${seperator}Nr of ${c3}userStories${cend} page: ".count($userStories);
+  if (count($userStories)>0)
+  {
+    echo "${seperator}First userStory expiringAt     :  " . gmdate("Y-m-d H:i:s", $userStories[0]->getExpiringAt());
+    echo " - " . floor(($userStories[0]->getExpiringAt()-time())/3600) . "h";
+    echo " " . floor((($userStories[0]->getExpiringAt()-time())%3600)/60) . "m ";
+    echo "${seperator}First userStory last mutation:  " . gmdate("Y-m-d H:i:s", $userStories[0]->getLastMutationData());
+    echo " - " . floor(($userStories[0]->getLastMutationData()-time())/3600) . "h";
+
+    echo "${seperator}First userStory user Id:  " . $userStories[0]->getOwner()->getId();
+    echo "${seperator}First userStory user Name:  " . $userStories[0]->getOwner()->getUsername();
+    echo "${seperator}${seperator}Note: no content of story, only the fact that a story of this user is present";
+    echo "${seperator}Fetch storie(s) with command:";
+    echo " '\$Instagram->getStories(".$userStories[0]->getOwner()->getId().");'";
+  }
+}

--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -25,7 +25,6 @@ class Endpoints
     const UNFOLLOW_URL = 'https://www.instagram.com/web/friendships/{{accountId}}/unfollow/';
     const USER_FEED = 'https://www.instagram.com/graphql/query/?query_id=17861995474116400&fetch_media_item_count=12&fetch_media_item_cursor=&fetch_comment_count=4&fetch_like=10';
     const USER_FEED2 = 'https://www.instagram.com/?__a=1';
-    const USER_FEED_id = 'https://www.instagram.com/graphql/query/?query_id=17861995474116400';
     const USER_FEED_hash = 'https://www.instagram.com/graphql/query/?query_hash=3f01472fb28fb8aca9ad9dbc9d4578ff';
     const INSTAGRAM_QUERY_URL = 'https://www.instagram.com/query/';
     const INSTAGRAM_CDN_URL = 'https://scontent.cdninstagram.com/';

--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -25,6 +25,8 @@ class Endpoints
     const UNFOLLOW_URL = 'https://www.instagram.com/web/friendships/{{accountId}}/unfollow/';
     const USER_FEED = 'https://www.instagram.com/graphql/query/?query_id=17861995474116400&fetch_media_item_count=12&fetch_media_item_cursor=&fetch_comment_count=4&fetch_like=10';
     const USER_FEED2 = 'https://www.instagram.com/?__a=1';
+    const USER_FEED_id = 'https://www.instagram.com/graphql/query/?query_id=17861995474116400';
+    const USER_FEED_hash = 'https://www.instagram.com/graphql/query/?query_hash=3f01472fb28fb8aca9ad9dbc9d4578ff';
     const INSTAGRAM_QUERY_URL = 'https://www.instagram.com/query/';
     const INSTAGRAM_CDN_URL = 'https://scontent.cdninstagram.com/';
     const ACCOUNT_JSON_PRIVATE_INFO_BY_ID = 'https://i.instagram.com/api/v1/users/{userId}/info/';

--- a/src/InstagramScraper/Model/UserStories.php
+++ b/src/InstagramScraper/Model/UserStories.php
@@ -14,6 +14,22 @@ class UserStories extends AbstractModel
     /** @var  Story[] */
     protected $stories;
 
+    /** @var  expiringAT */
+    protected $expiringAt=0;
+
+    /** @var  lastMutationData */
+    protected $lastMutationData=0;
+
+    public function getExpiringAt()
+    {
+        return $this->expiringAt;
+    }
+
+    public function getLastMutationData()
+    {
+        return $this->lastMutationData;
+    }
+
     public function setOwner($owner)
     {
         $this->owner = $owner;
@@ -37,5 +53,21 @@ class UserStories extends AbstractModel
     public function getStories()
     {
         return $this->stories;
+    }
+
+    /**
+     * @param $value
+     * @param $prop
+     */
+    protected function initPropertiesCustom($value, $prop, $arr)
+    {
+        switch ($prop) {
+          case 'expiring_at':
+              $this->expiringAt = (int)$value;
+              break;
+          case 'latest_reel_media':
+              $this->lastMutationData = (int)$value;
+              break;
+        }
     }
 }

--- a/src/InstagramScraper/Model/UserStories.php
+++ b/src/InstagramScraper/Model/UserStories.php
@@ -17,17 +17,17 @@ class UserStories extends AbstractModel
     /** @var  expiringAT */
     protected $expiringAt=0;
 
-    /** @var  lastMutationData */
-    protected $lastMutationData=0;
+    /** @var  lastMutatedAt */
+    protected $lastMutatedAt=0;
 
     public function getExpiringAt()
     {
         return $this->expiringAt;
     }
 
-    public function getLastMutationData()
+    public function getLastMutatedAt()
     {
-        return $this->lastMutationData;
+        return $this->lastMutatedAt;
     }
 
     public function setOwner($owner)
@@ -66,7 +66,7 @@ class UserStories extends AbstractModel
               $this->expiringAt = (int)$value;
               break;
           case 'latest_reel_media':
-              $this->lastMutationData = (int)$value;
+              $this->lastMutatedAt = (int)$value;
               break;
         }
     }


### PR DESCRIPTION
Added getPaginateFeed and added parameters to retrieve number of media/comments in query. Get paginate feed returns both media and stories. To implement this using hash endpoint in stead of id endpoint (see endpoints USER_FEED (old) and USER_FEED_hash (new).
Added exemple to document and test change.

Note: a call to getFeed() behaves the same as in the old version

changes to endpoint.php:
- added endpoint USER_FEED_hash

changes to Instagram.php:
- Added method getPaginateFeed($mediaCount=12, $maxId='', $commentCount=6, $likeCount=4)
- (note: likeCount should work like this, however does not seem to do anything)
- Added parameters to getFeed($mediaCount=12, $maxId='', $commentCount=6, $likeCount=4, $paginateInd=false)
- Changed endpoint in getFeed (to be able to return feed+stories in 1 request)
- Added function getUserStories that returns userStorie without content (same behaviour as getPaginateFeed)

changes to Model/userStorie
- added properties lastMutationData and $expiringAt
- added get functions for properties
- added initPropertiesCustom to parse properties


Please let me know if these changes are ok or should be implemented differently


Richard