### PR TITLE
Highlights incl stories incl exemple

### DIFF
--- a/examples/getHighlights.php
+++ b/examples/getHighlights.php
@@ -4,7 +4,7 @@ use Phpfastcache\Helper\Psr16Adapter;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'ricdijk', '@leusdeN2020', new Psr16Adapter('Files'));
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'user', 'passwd', new Psr16Adapter('Files'));
 $instagram->login();
 
 //$userId = $instagram->getAccount('instagram')->getId();

--- a/examples/getHighlights.php
+++ b/examples/getHighlights.php
@@ -3,14 +3,20 @@ use Phpfastcache\Helper\Psr16Adapter;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'username', 'password', new Psr16Adapter('Files'));
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'username', 'passwd', new Psr16Adapter('Files'));
 $instagram->login();
 
-$userId = $instagram->getAccount('instagram')->getId();
+//$userId = $instagram->getAccount('instagram')->getId();
+$userId = 556625332;
+echo "<pre>";
 
 $highlights = $instagram->getHighlights($userId);
+$hcount=0;
 foreach ($highlights as $highlight) {
-    echo "Highlight info:\n";
+    $hcount++;
+    echo "\n------------------------------------------------------------------------------------------------------------------------\n";
+    echo "Highlight info ($hcount):\n";
+    echo "<img width=80 src='".$highlight->getImageThumbnailUrl()."'>\n";
     echo "Id: {$highlight->getId()}\n";
     echo "Title: {$highlight->getTitle()}\n";
     echo "Image thumbnail url: {$highlight->getImageThumbnailUrl()}\n";
@@ -21,5 +27,32 @@ foreach ($highlights as $highlight) {
     echo " Id: {$account->getId()}\n";
     echo " Username: {$account->getUsername()}\n";
     echo " Profile pic url: {$account->getProfilePicUrl()}\n";
-    echo "\n";
+
+    echo "------------------------------------------------------------------------------------------------------------------------\n";
+
+    $userStories=$instagram->richd_test($highlight->getId());
+    for ($i=0; $i<count($userStories);$i++)
+    {
+      $stories = $userStories[$i]->getStories();
+      //$owner   = $userStories[$i]->getOwner();
+      //echo "\n===========================================================";
+      //echo "\nUserStorie: " . $i;
+      //echo "\nId:         " . $owner['id'];
+      //echo "\nUserName:   " . $owner['username'];
+
+      //for each stories => get Story
+      for ($j=0; $j<count($stories);$j++)
+      {
+          $story = $stories[$j];
+          echo "\n--------------------------------------------------------";
+          echo "\nStorie:         " . $j;
+          echo "\nId:             " . $story['id'];
+          echo "\nCreation Time:  " . $story['createdTime'];
+          echo "\nType:           " . $story['type'];
+          echo "\n<img height=100 src=\"".$story['imageThumbnailUrl']."\">";
+
+      }
+    }
+
 }
+echo "</pre>";

--- a/examples/getHighlights.php
+++ b/examples/getHighlights.php
@@ -1,9 +1,10 @@
 <?php
+ini_set('display_errors', 1);ini_set('display_startup_errors', 1);error_reporting(E_ALL);
 use Phpfastcache\Helper\Psr16Adapter;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'username', 'passwd', new Psr16Adapter('Files'));
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'ricdijk', '@leusdeN2020', new Psr16Adapter('Files'));
 $instagram->login();
 
 //$userId = $instagram->getAccount('instagram')->getId();
@@ -30,7 +31,7 @@ foreach ($highlights as $highlight) {
 
     echo "------------------------------------------------------------------------------------------------------------------------\n";
 
-    $userStories=$instagram->richd_test($highlight->getId());
+    $userStories=$instagram->getHighlightStories($highlight->getId());
     for ($i=0; $i<count($userStories);$i++)
     {
       $stories = $userStories[$i]->getStories();

--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -36,6 +36,7 @@ class Endpoints
     const DELETE_COMMENT_URL = 'https://www.instagram.com/web/comments/{mediaId}/delete/{commentId}/';
     const ACCOUNT_MEDIAS2 = 'https://www.instagram.com/graphql/query/?query_id=17880160963012870&id={{accountId}}&first=10&after=';
     const HIGHLIGHT_URL = 'https://www.instagram.com/graphql/query/?query_hash=c9100bf9110dd6361671f113dd02e7d6&variables={"user_id":"{userId}","include_chaining":false,"include_reel":true,"include_suggested_users":false,"include_logged_out_extras":false,"include_highlight_reels":true,"include_live_status":false}';
+    const HIGHLIGHT_STORIES = 'https://www.instagram.com/graphql/query/?query_hash=45246d3fe16ccc6577e0bd297a5db1ab';
     const THREADS_URL = 'https://www.instagram.com/direct_v2/web/inbox/?persistentBadging=true&folder=&limit={limit}&thread_message_limit={messageLimit}&cursor={cursor}';
 
     // Look alike??


### PR DESCRIPTION
Note: This pull request is partly the same as getStorieReelHighLightLocation, I think it is better to implement one (but not sure which is the best in the phylosophy of this API).
difference:
HighlightsInclStoriesInclExemple => 2 functions with 1 argument
getStorieReelHighLightLocation  => 1 function with multiple arguments

Added getHightlightStories()
changed example getHighlights to include getHighlightStories

used different instagram hash as request #849, since that hash does not seem to work properly

Note:
You can use this query_hash for both Stories and HighlightStories, but with different variables
('highlight_reel_ids' and 'reel_ids'). If it is better to put it in one function (with two arguments) please let me now. I will then create a getStories function with 3 arguments, to also include 'location_ids'.

