### PR TITLE
Get storie reel high light location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 phpunit.phar
 tests/sessions
 phpunit.xml
+settings.json

--- a/examples/getHighlights.php
+++ b/examples/getHighlights.php
@@ -4,7 +4,11 @@ use Phpfastcache\Helper\Psr16Adapter;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'user', 'passwd', new Psr16Adapter('Files'));
+$settings=json_decode(file_get_contents('settings.json'));
+$username = $settings->username;
+$password = $settings->password;
+
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), $username, $password, new Psr16Adapter('Files'));
 $instagram->login();
 
 //$userId = $instagram->getAccount('instagram')->getId();

--- a/examples/getHighlights.php
+++ b/examples/getHighlights.php
@@ -1,16 +1,23 @@
 <?php
+ini_set('display_errors', 1);ini_set('display_startup_errors', 1);error_reporting(E_ALL);
 use Phpfastcache\Helper\Psr16Adapter;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'username', 'password', new Psr16Adapter('Files'));
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'user', 'passwd', new Psr16Adapter('Files'));
 $instagram->login();
 
-$userId = $instagram->getAccount('instagram')->getId();
+//$userId = $instagram->getAccount('instagram')->getId();
+$userId = 556625332;
+echo "<pre>";
 
 $highlights = $instagram->getHighlights($userId);
+$hcount=0;
 foreach ($highlights as $highlight) {
-    echo "Highlight info:\n";
+    $hcount++;
+    echo "\n------------------------------------------------------------------------------------------------------------------------\n";
+    echo "Highlight info ($hcount):\n";
+    echo "<img width=80 src='".$highlight->getImageThumbnailUrl()."'>\n";
     echo "Id: {$highlight->getId()}\n";
     echo "Title: {$highlight->getTitle()}\n";
     echo "Image thumbnail url: {$highlight->getImageThumbnailUrl()}\n";
@@ -21,5 +28,32 @@ foreach ($highlights as $highlight) {
     echo " Id: {$account->getId()}\n";
     echo " Username: {$account->getUsername()}\n";
     echo " Profile pic url: {$account->getProfilePicUrl()}\n";
-    echo "\n";
+
+    echo "------------------------------------------------------------------------------------------------------------------------\n";
+
+    $userStories=$instagram->getHighlightStories($highlight->getId());
+    for ($i=0; $i<count($userStories);$i++)
+    {
+      $stories = $userStories[$i]->getStories();
+      //$owner   = $userStories[$i]->getOwner();
+      //echo "\n===========================================================";
+      //echo "\nUserStorie: " . $i;
+      //echo "\nId:         " . $owner['id'];
+      //echo "\nUserName:   " . $owner['username'];
+
+      //for each stories => get Story
+      for ($j=0; $j<count($stories);$j++)
+      {
+          $story = $stories[$j];
+          echo "\n--------------------------------------------------------";
+          echo "\nStorie:         " . $j;
+          echo "\nId:             " . $story['id'];
+          echo "\nCreation Time:  " . $story['createdTime'];
+          echo "\nType:           " . $story['type'];
+          echo "\n<img height=100 src=\"".$story['imageThumbnailUrl']."\">";
+
+      }
+    }
+
 }
+echo "</pre>";

--- a/examples/getPaginateFeed.php
+++ b/examples/getPaginateFeed.php
@@ -21,7 +21,7 @@ use Phpfastcache\Helper\Psr16Adapter;
 require __DIR__ . '/../vendor/autoload.php';
 
 $seperator = PHP_SAPI === 'cli' ? "\n" : "<br>\n";
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'ricdijk', '@leusdeN2020', new Psr16Adapter('Files'));
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'username', 'passwd', new Psr16Adapter('Files'));
 $instagram->login();
 $instagram->saveSession(3600*24);
 

--- a/examples/getStories.php
+++ b/examples/getStories.php
@@ -3,7 +3,12 @@ use Phpfastcache\Helper\Psr16Adapter;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'username', 'password', new Psr16Adapter('Files'));
+
+$settings=json_decode(file_get_contents('settings.json'));
+$username = $settings->username;
+$password = $settings->password;
+
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), $username, $password, new Psr16Adapter('Files'));
 $instagram->login();
 
 $stories = $instagram->getStories();

--- a/examples/getStoriesFromUserStories.php
+++ b/examples/getStoriesFromUserStories.php
@@ -4,9 +4,13 @@ ini_set('display_errors', 1);ini_set('display_startup_errors', 1);error_reportin
 require __DIR__ . '/../vendor/autoload.php';
 use Phpfastcache\Helper\Psr16Adapter;
 
-$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), 'user', 'passed', new Psr16Adapter('Files'));
+$settings=json_decode(file_get_contents('settings.json'));
+$username = $settings->username;
+$password = $settings->password;
+
+$instagram = \InstagramScraper\Instagram::withCredentials(new \GuzzleHttp\Client(), $username, $password, new Psr16Adapter('Files'));
 $instagram->login();
-$instagram->saveSession();
+$instagram->saveSession(10*24*3600);
 
 
 // *************************** get storie from unsetStories **********************************

--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -36,6 +36,7 @@ class Endpoints
     const DELETE_COMMENT_URL = 'https://www.instagram.com/web/comments/{mediaId}/delete/{commentId}/';
     const ACCOUNT_MEDIAS2 = 'https://www.instagram.com/graphql/query/?query_id=17880160963012870&id={{accountId}}&first=10&after=';
     const HIGHLIGHT_URL = 'https://www.instagram.com/graphql/query/?query_hash=c9100bf9110dd6361671f113dd02e7d6&variables={"user_id":"{userId}","include_chaining":false,"include_reel":true,"include_suggested_users":false,"include_logged_out_extras":false,"include_highlight_reels":true,"include_live_status":false}';
+    const HIGHLIGHT_STORIES = 'https://www.instagram.com/graphql/query/?query_hash=45246d3fe16ccc6577e0bd297a5db1ab';
     const THREADS_URL = 'https://www.instagram.com/direct_v2/web/inbox/?persistentBadging=true&folder=&limit={limit}&thread_message_limit={messageLimit}&cursor={cursor}';
 
     // Look alike??

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -139,6 +139,11 @@ class Instagram
         if (is_object($rawError)) {
             $str = '';
             foreach ($rawError as $key => $value) {
+                //to avoid erros in an error function make sure all are string before concat operation
+                if (is_array($value))  $value=json_encode((array)$value);
+                if (is_object($value)) $value=json_encode((array)$value);
+                if (is_array($key))    $key=json_encode((array)$key);
+                if (is_object($key))   $key=json_encode((array)$key);
                 $str .= ' ' . $key . ' => ' . $value . ';';
             }
             return $str;
@@ -1683,16 +1688,23 @@ class Instagram
             'accounts' => $accounts
         ];
     }
-
     /**
      * @param array $reel_ids - array of instagram user ids
      * @return array
      * @throws InstagramException
      */
-    public function getStories($reel_ids = null)
+    public function getStories($reel_ids = null, $highlight_reel_ids=[], $location_ids=[])
     {
+        if (empty($reel_ids) )              $reel_ids           = [];
+        elseif (!is_array($reel_ids))       $reel_ids           = [$reel_ids];
+        if (!is_array($highlight_reel_ids)) $highlight_reel_ids = [$highlight_reel_ids];
+        if (!is_array($location_ids))       $location_ids       = [$location_ids];
+    //-------------------------------------------------------------------------------------------------------------
+    // if no arguments: get user stories
+    //-------------------------------------------------------------------------------------------------------------
         $variables = ['precomposed_overlay' => false, 'reel_ids' => []];
-        if (empty($reel_ids)) {
+        if ($reel_ids == [] && $highlight_reel_ids == [] && $location_ids==[]) {
+
             $response = Request::get(Endpoints::getUserStoriesLink($variables),
                 $this->generateHeaders($this->userSession));
 
@@ -1707,36 +1719,44 @@ class Instagram
             }
 
             foreach ($jsonResponse['data']['user']['feed_reels_tray']['edge_reels_tray_to_reel']['edges'] as $edge) {
-                $variables['reel_ids'][] = $edge['node']['id'];
+                $reel_ids[] = $edge['node']['id'];
             }
-        } else {
-            $variables['reel_ids'] = $reel_ids;
         }
+    //-------------------------------------------------------------------------------------------------------------
+    // Get stories from reel_ids (users), highlight_ids and/or location_ids
+    //-------------------------------------------------------------------------------------------------------------
+    $variables = [
+             'highlight_reel_ids'=> $highlight_reel_ids,
+             'reel_ids'=> $reel_ids,
+             'location_ids'=> $location_ids,
+             'precomposed_overlay'=> False,
+      ];
 
-        $response = Request::get(Endpoints::getStoriesLink($variables),
-            $this->generateHeaders($this->userSession));
+      $url = Endpoints::HIGHLIGHT_STORIES . '&variables=' . json_encode($variables);
+      $response = Request::get($url, $this->generateHeaders($this->userSession));
 
-        if ($response->code !== static::HTTP_OK) {
-            throw new InstagramException('Response code is ' . $response->code . '. Body: ' . static::getErrorBody($response->body) . ' Something went wrong. Please report issue.', $response->code);
-        }
+      if ($response->code !== static::HTTP_OK) {
+          throw new InstagramException('Response code is ' . $response->code . '. Body: ' . static::getErrorBody($response->body) . ' Something went wrong. Please report issue.', $response->code);
+      }
 
-        $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
+      $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
 
-        if (empty($jsonResponse['data']['reels_media'])) {
-            return [];
-        }
+      if (empty($jsonResponse['data']['reels_media'])) {
+          return [];
+      }
 
-        $stories = [];
-        foreach ($jsonResponse['data']['reels_media'] as $user) {
-            $UserStories = UserStories::create();
-            $UserStories->setOwner(Account::create($user['user']));
-            foreach ($user['items'] as $item) {
-                $UserStories->addStory(Story::create($item));
-            }
-            $stories[] = $UserStories;
-        }
-        return $stories;
-    }
+      $stories = [];
+      foreach ($jsonResponse['data']['reels_media'] as $highlight) {
+          $UserStories = UserStories::create();
+          $UserStories->setOwner(Account::create($highlight['owner']));
+          foreach ($highlight['items'] as $item) {
+              $UserStories->addStory(Story::create($item));
+          }
+          $stories[] = $UserStories;
+      }
+      return $stories;
+  }
+
 
     /**
      * @param bool $force
@@ -2170,40 +2190,7 @@ class Instagram
      */
     public function getHighlightStories($highlight_reel_ids)
     {
-        if (!is_array($highlight_reel_ids)) {
-            $highlight_reel_ids = [$highlight_reel_ids];
-        }
-
-        $variables = [
-               'highlight_reel_ids'=> $highlight_reel_ids,
-               'reel_ids'=> [],
-               'location_ids'=> [],
-               'precomposed_overlay'=> False,
-        ];
-
-        $url = Endpoints::HIGHLIGHT_STORIES . '&variables=' . json_encode($variables);
-        $response = Request::get($url, $this->generateHeaders($this->userSession));
-
-        if ($response->code !== static::HTTP_OK) {
-            throw new InstagramException('Response code is ' . $response->code . '. Body: ' . static::getErrorBody($response->body) . ' Something went wrong. Please report issue.', $response->code);
-        }
-
-        $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
-
-        if (empty($jsonResponse['data']['reels_media'])) {
-            return [];
-        }
-
-        $stories = [];
-        foreach ($jsonResponse['data']['reels_media'] as $highlight) {
-            $UserStories = UserStories::create();
-            $UserStories->setOwner(Account::create($highlight['owner']));
-            foreach ($highlight['items'] as $item) {
-                $UserStories->addStory(Story::create($item));
-            }
-            $stories[] = $UserStories;
-        }
-        return $stories;
+      return $this->getStories([], $highlight_reel_ids, []);
     }
 
     /**


### PR DESCRIPTION
Note: This pull request is partly the same as HighlightsInclStoriesInclExemple, I think it is better to implement one (but not sure which is the best in the phylosophy of this API.
difference:
HighlightsInclStoriesInclExemple => 2 functions with 1 argument
getStorieReelHighLightLocation  => 1 functions with multiple argument

Thinking about the getHilghlightStories function and the thread on it, I saw that with this query_hash it is possible to put both methods in one function.
And looking at the variables, there also must be stories from 'location_ids'.

So I changed the 'getStories' function:
- remain backwards compatible
- allow loading stories from 
  - reel_ids (users)
  - highlight_ids
  - location_ids

Tested the functionality with:
- getStories()
- getHighlights()
- getSToriesFromUserStories()

I think that can be addressed all in one call, but did not test this.

