### PR TITLE
fixed the false throwing of the exception

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1603,7 +1603,7 @@ class Instagram
             }
 
             $edgesArray = $jsonResponse['data']['user']['edge_follow']['edges'];
-            if (count($edgesArray) === 0) {
+            if ((count($edgesArray) === 0) && ($index === 0)) {
                 throw new InstagramException('Failed to get followers of account id ' . $accountId . '. The account is private.', static::HTTP_FORBIDDEN);
             }
 


### PR DESCRIPTION
On one of my accounts, Instagram gives out an extra page if the number of subscribers is a multiple of 20. This does not happen on other accounts.
The extra page has no **edges** and **has_next_page = false**. So I made that the exception is thrown only on the first page if it is empty.