### PR TITLE
Adding prop isProfessionalAccount to account model

### DIFF
--- a/src/InstagramScraper/Model/Account.php
+++ b/src/InstagramScraper/Model/Account.php
@@ -138,6 +138,11 @@ class Account extends AbstractModel
     /**
      * @var bool
      */
+    protected $isProfessionalAccount = false;
+
+    /**
+     * @var bool
+     */
     protected $isJoinedRecently = false;
 
     /**
@@ -378,6 +383,14 @@ class Account extends AbstractModel
     /**
      * @return bool
      */
+    public function isProfessionalAccount()
+    {
+        return $this->isProfessionalAccount;
+    }
+
+    /**
+     * @return bool
+     */
     public function isJoinedRecently()
     {
         return $this->isJoinedRecently;
@@ -505,6 +518,9 @@ class Account extends AbstractModel
                 break;
             case 'is_business_account':
                 $this->isBusinessAccount = (bool)$value;
+                break;
+            case 'is_professional_account':
+                $this->isProfessionalAccount = (bool)$value;
                 break;
             case 'is_joined_recently':
                 $this->isJoinedRecently = (bool)$value;


### PR DESCRIPTION
Instagram currently has three types of accounts:
- usual
- professional
- business

If an account has a professional status, it does not have to be a business status. 