### PR TITLE
Allow getMediasByTag to GraphQL or data access

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1204,11 +1204,13 @@ class Instagram
             if (!is_array($arr)) {
                 throw new InstagramException('Response decoding failed. Returned data corrupted or this library outdated. Please report issue');
             }
-            if (empty($arr['data']['hashtag']['edge_hashtag_to_media']['count'])) {
+            $rootKey = array_key_exists('graphql', $arr) ? 'graphql' : 'data';
+            
+            if (empty($arr[$rootKey]['hashtag']['edge_hashtag_to_media']['count'])) {
                 return [];
             }
 
-            $nodes = $arr['data']['hashtag']['edge_hashtag_to_media']['edges'];
+            $nodes = $arr[$rootKey]['hashtag']['edge_hashtag_to_media']['edges'];
             foreach ($nodes as $mediaArray) {
                 if ($index === $count) {
                     return $medias;
@@ -1227,8 +1229,8 @@ class Instagram
             if (empty($nodes)) {
                 return $medias;
             }
-            $maxId = $arr['data']['hashtag']['edge_hashtag_to_media']['page_info']['end_cursor'];
-            $hasNextPage = $arr['data']['hashtag']['edge_hashtag_to_media']['page_info']['has_next_page'];
+            $maxId = $arr[$rootKey]['hashtag']['edge_hashtag_to_media']['page_info']['end_cursor'];
+            $hasNextPage = $arr[$rootKey]['hashtag']['edge_hashtag_to_media']['page_info']['has_next_page'];
         }
         return $medias;
     }


### PR DESCRIPTION
Upgrading a project to php 8 I lost the functionality of `getMediasByTag()` only ever getting a empty array. It looks like a PR changed the array key from ['graphql'] to ['data'] yet 'data' doesn't exist on the responses I get, while 'graphql' does.

On the potential that the response might A) differ from time to time or B) somehow be different based on the request origin or something (i.e. I can't prove ['data'] doesn't work for others, while my ['graphql'] doesn't) I propose the following fallback 'reversion' - check for the existence of ['graphql'] then try ['data'] if it's not found.