### PR TITLE
Make getCacheKey API public.

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -2048,7 +2048,7 @@ class Instagram
     /**
      * @return string
      */
-    private function getCacheKey()
+    public function getCacheKey()
     {
         return md5($this->sessionUsername);
     }


### PR DESCRIPTION
See details in [issue](https://github.com/postaddictme/instagram-php-scraper/issues/1025).