### PR TITLE
Updated Instagram::getLocationById json response structure path from graphql to native_location_data

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1689,7 +1689,7 @@ class Instagram
 
         $this->parseCookies($response->headers);
         $jsonResponse = $this->decodeRawBodyToJson($response->raw_body);
-        return Location::create($jsonResponse['graphql']['location']);
+        return Location::create($jsonResponse['native_location_data']['location_info']);
     }
 
     /**


### PR DESCRIPTION
Seems that Endpoints::getMediasJsonByLocationIdLink requests returned Json structure has changed. Previously used _graphql_ value is returned as null. Now all data is returned as _native_location_data_ value.

Updated Instagram::getLocationById to use new structure. 