### PR TITLE
Align return of getFollowing() with getFollowers()

### DIFF
--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -1895,8 +1895,8 @@ class Instagram
      */
     public function getFollowing($accountId, $count = 20, $pageSize = 20, $delayed = true)
     {
-        $res = $this->getPaginateFollowing($accountId, $count, $pageSize, $delayed, '');
-        return $res;
+        $result = $this->getPaginateFollowing($accountId, $count, $pageSize, $delayed, '');
+        return $result['accounts'] ?? [];
     }
 
     /**


### PR DESCRIPTION
getFollowers() returns an array only consisting of the `accounts` while getFollowing() additionally returns `hasNextPage` and `nextPage`. This is irritating, thus the return array of getFollowing() has been adapted.